### PR TITLE
Add sleep to solve TPX3 configuration error

### DIFF
--- a/user/timepix3/module/src/Timepix3Producer.cxx
+++ b/user/timepix3/module/src/Timepix3Producer.cxx
@@ -375,12 +375,15 @@ void Timepix3Producer::DoConfigure() {
   if (!spidrctrl) {
     EUDAQ_THROW("DoConfigure: spidrctrl was not initialized. Can not configure it.");
     return;
-  }
-
+  
+}
   auto config = GetConfiguration();
   EUDAQ_USER("Timepix3Producer configuring: " + config->Name());
   // Configuration file values are accessible as config->Get(name, default)
 
+  // sleep for 1 second, to make sure the TLU clock is already present
+  sleep (1);
+  
   // set whether external clock (TLU) is used or device runs standalone
   m_extRefClk = config->Get("external_clock", false);
   if (!spidrctrl->setExtRefClk(m_extRefClk)) {

--- a/user/timepix3/module/src/Timepix3Producer.cxx
+++ b/user/timepix3/module/src/Timepix3Producer.cxx
@@ -375,15 +375,15 @@ void Timepix3Producer::DoConfigure() {
   if (!spidrctrl) {
     EUDAQ_THROW("DoConfigure: spidrctrl was not initialized. Can not configure it.");
     return;
-  
-}
+  }
+
   auto config = GetConfiguration();
   EUDAQ_USER("Timepix3Producer configuring: " + config->Name());
   // Configuration file values are accessible as config->Get(name, default)
 
   // sleep for 1 second, to make sure the TLU clock is already present
   sleep (1);
-  
+
   // set whether external clock (TLU) is used or device runs standalone
   m_extRefClk = config->Get("external_clock", false);
   if (!spidrctrl->setExtRefClk(m_extRefClk)) {


### PR DESCRIPTION
Added 1 second sleep before Timepix3 configuration, to make sure TLU clock is present before accessing device