### PR TITLE
CP2 --> return false after detecting 2nd T0

### DIFF
--- a/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
+++ b/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
@@ -13,7 +13,7 @@ namespace eudaq {
     bool Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const override;
     static const uint32_t m_id_factory = eudaq::cstr2hash("CaribouCLICpix2Event");
   private:
-    static bool t0_seen_;
+    static size_t t0_seen_;
     static uint64_t last_shutter_open_;
   };
 

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -131,6 +131,8 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   // Check for a sane shutter:
   if(shutter_open > shutter_close) {
     EUDAQ_WARN("Frame with shutter close before shutter open: " + std::to_string(ev->GetEventNumber()));
+    // should this also be interpreted as second T0?
+    second_t0_seen_ = true; // ??
     return false;
   }
 

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -12,6 +12,7 @@ namespace{
 }
 
 bool CLICpix2Event2StdEventConverter::t0_seen_(false);
+bool CLICpix2Event2StdEventConverter::second_t0_seen_(false);
 uint64_t CLICpix2Event2StdEventConverter::last_shutter_open_(0);
 bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
   auto ev = std::dynamic_pointer_cast<const eudaq::RawEvent>(d1);
@@ -137,6 +138,8 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   if(!t0_seen_) {
     // Last shutter open had higher timestamp than this one:
     t0_seen_ = (last_shutter_open_ > shutter_open);
+  } else if(!second_t0_seen_){
+    second_t0_seen_ = (last_shutter_open_ > shutter_open);
   }
   last_shutter_open_ = shutter_open;
 
@@ -145,6 +148,10 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   // No T0 signal seen yet, dropping frame:
   if(drop_before_t0 && !t0_seen_) {
     return false;
+  }
+  // drop everything after second t0 has been seen:
+  if(second_t0_seen_) {
+      return false;
   }
 
   // Decode the data:

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -147,7 +147,7 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   }
   // drop everything after second t0 has been seen:
   if(t0_seen_>1) {
-      EUDAQ_WARN("Detected T0" << t0_seen_ << " times.");
+      EUDAQ_WARN("Detected T0 " + std::to_string(t0_seen_) + " times.");
       return false;
   }
 


### PR DESCRIPTION
The first T0 is determined by checking for 
```cpp
  // Check if there was a T0:
  if(!t0_seen_) {
    // Last shutter open had higher timestamp than this one:
    t0_seen_ = (last_shutter_open_ > shutter_open);
  }
```
I'm now checking for a second T0 with the same logic, i.e. `last_shutter_open_ > shutter_open`.

A few lines above, there was already the check 
```cpp
  // Check for a sane shutter:
  if(shutter_open > shutter_close) {
    EUDAQ_WARN("Frame with shutter close before shutter open: " + std::to_string(ev->GetEventNumber()));
    return false;
  }
```
I'm wondering if we should also count this as the detection of a second T0...What do you think?
```cpp
  // Check for a sane shutter:
  if(shutter_open > shutter_close) {
    EUDAQ_WARN("Frame with shutter close before shutter open: " + std::to_string(ev->GetEventNumber()));
    // should this also be interpreted as second T0?
    second_t0_seen_ = true; // ??
    return false;
  }
```