### PR TITLE
Fix trigger timestamp (SpidrTrigger and TLU fine)

### DIFF
--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -38,6 +38,11 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
     return false;
   }
 
+  // format of TDC data from SPIDR:
+  // 63   59   55   51   47   43   39   35   31   27   23   19   15   11   7    3  0
+  // 0110 1111 EEEE EEEE EEEE TTTT TTTT TTTT TTTT TTTT TTTT TTTT TTTT TTTF FFF0 0000
+  // where: E=event_no, T=coarse_timestamp, F=fine_timestamp (0x0 to 0xc)
+
   unsigned long long int stamp = (trigdata & 0x1E0) >> 5;
   long long int timestamp_raw = static_cast<long long int>(trigdata & 0xFFFFFFFFE00) >> 9;
   long long int timestamp = 0;

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -43,7 +43,7 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   // 0110 1111 EEEE EEEE EEEE TTTT TTTT TTTT TTTT TTTT TTTT TTTT TTTT TTTF FFF0 0000
   // where: E=event_no, T=coarse_timestamp, F=fine_timestamp (0x0 to 0xc)
 
-  unsigned long long int stamp = (trigdata & 0x1E0) >> 5;
+  unsigned int stamp = (trigdata & 0x1E0) >> 5;
   long long int timestamp_raw = static_cast<long long int>(trigdata & 0xFFFFFFFFE00) >> 9;
   long long int timestamp = 0;
 

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -68,8 +68,8 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   timestamp = timestamp_raw + (static_cast<long long int>(m_TDCoverflowCounter) << 35);
 
   // Calculate timestamp in picoseconds assuming 320 MHz clock:
-  uint64_t triggerTime = (timestamp + static_cast<long long int>(stamp) / 12) * 3125;
-
+  uint64_t triggerTime = (timestamp + static_cast<long long int>(stamp) / 12.) * 3125;
+  
   // Set timestamps for StdEvent in nanoseconds (timestamps are picoseconds):
   d2->SetTimeBegin(triggerTime);
   d2->SetTimeEnd(triggerTime);

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -52,6 +52,13 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
     EUDAQ_WARN("Invalid data found in packet " + std::to_string(ev->GetEventNumber()));
     return false;
   }
+  if(stamp == 0) {
+      // stamp value = 0 indicates a TDC error
+      EUDAQ_WARN("Invalid TDC stamp received in packet " + std::to_string(ev->GetEventNumber()));
+  } else {
+      // stamp value ranges from 1 to 12 correspond to coarse timestamp + <0-11>
+      stamp--;
+  }
 
   // if jump back in time is larger than 1 sec, overflow detected...
   if((m_syncTimeTDC - timestamp_raw) > 0x1312d000) {

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -54,10 +54,8 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   }
   if(stamp == 0) {
       // stamp value = 0 indicates a TDC error
-      EUDAQ_WARN("Invalid TDC stamp received in packet " + std::to_string(ev->GetEventNumber()));
-  } else {
       // stamp value ranges from 1 to 12 correspond to coarse timestamp + <0-11>
-      stamp--;
+      EUDAQ_WARN("Invalid TDC stamp received in packet " + std::to_string(ev->GetEventNumber()));
   }
 
   // if jump back in time is larger than 1 sec, overflow detected...

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -71,17 +71,9 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   // Set timestamps for StdEvent in nanoseconds (timestamps are picoseconds):
   d2->SetTimeBegin(triggerTime);
   d2->SetTimeEnd(triggerTime);
-
+  
   // Identify the detetor type
   d2->SetDetectorType("SpidrTrigger");
-
-  // Create a StandardPlane representing one DUMMY sensor plane
-  eudaq::StandardPlane plane(0, "SPIDR", "SpidrTrigger");
-  plane.SetSizeZS(1, 1, 0);
-
-  // creating new pixel object with dummy hit containing the timestammp
-  plane.PushPixel(0, 0, 0, triggerTime);
-  d2->AddPlane(plane);
 
   return true;
 }

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -61,9 +61,17 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   // Set timestamps for StdEvent in nanoseconds (timestamps are picoseconds):
   d2->SetTimeBegin(triggerTime);
   d2->SetTimeEnd(triggerTime);
-  
+
   // Identify the detetor type
   d2->SetDetectorType("SpidrTrigger");
+
+  // Create a StandardPlane representing one DUMMY sensor plane
+  eudaq::StandardPlane plane(0, "SPIDR", "SpidrTrigger");
+  plane.SetSizeZS(1, 1, 0);
+
+  // creating new pixel object with dummy hit containing the timestammp
+  plane.PushPixel(0, 0, 0, triggerTime);
+  d2->AddPlane(plane);
 
   return true;
 }

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -66,7 +66,7 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   timestamp = timestamp_raw + (static_cast<long long int>(m_TDCoverflowCounter) << 35);
 
   // Calculate timestamp in picoseconds assuming 320 MHz clock:
-  uint64_t triggerTime = static_cast<uint64_t>((static_cast<double>(timestamp) + static_cast<double>(stamp) / 12.) * 3125);
+  uint64_t triggerTime = timestamp * 3125 +(stamp * 3125) / 12;
 
   // Set timestamps for StdEvent in nanoseconds (timestamps are picoseconds):
   d2->SetTimeBegin(triggerTime);

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -68,8 +68,8 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   timestamp = timestamp_raw + (static_cast<long long int>(m_TDCoverflowCounter) << 35);
 
   // Calculate timestamp in picoseconds assuming 320 MHz clock:
-  uint64_t triggerTime = (timestamp + static_cast<long long int>(stamp) / 12.) * 3125;
-  
+  uint64_t triggerTime = static_cast<uint64_t>((static_cast<double>(timestamp) + static_cast<double>(stamp) / 12.) * 3125);
+
   // Set timestamps for StdEvent in nanoseconds (timestamps are picoseconds):
   d2->SetTimeBegin(triggerTime);
   d2->SetTimeEnd(triggerTime);

--- a/user/tlu/exe/src/euCliTluReader.cxx
+++ b/user/tlu/exe/src/euCliTluReader.cxx
@@ -81,8 +81,8 @@ int main(int /*argc*/, const char **argv) {
       auto timeStampEnd = ev->GetTimestampEnd();
       auto particles = ev->GetTag("PARTICLES", "NAN");
       auto triggersFired = ev->GetTag("TRIGGER", "NAN");
-      auto scaler0 = ev->GetTag("SCALER0", "NAN"); 
-      auto scaler1 = ev->GetTag("SCALER1", "NAN"); 
+      auto scaler0 = ev->GetTag("SCALER0", "NAN");
+      auto scaler1 = ev->GetTag("SCALER1", "NAN");
       auto scaler2 = ev->GetTag("SCALER2", "NAN");
       auto scaler3 = ev->GetTag("SCALER3", "NAN");
       auto scaler4 = ev->GetTag("SCALER4", "NAN");
@@ -93,15 +93,15 @@ int main(int /*argc*/, const char **argv) {
       auto finets3 = ev->GetTag("FINE_TS3", "NAN");
       auto finets4 = ev->GetTag("FINE_TS4", "NAN");
       auto finets5 = ev->GetTag("FINE_TS5", "NAN");
-      std::cout << runNumber << "," << 
-      		   eventNumber << "," << 
-		   triggerNumber << "," << 
-		   timeStampBegin << "," << 
-		   timeStampEnd << "," << 
+      std::cout << runNumber << "," <<
+      		   eventNumber << "," <<
+		   triggerNumber << "," <<
+		   timeStampBegin << "," <<
+		   timeStampEnd << "," <<
 		   particles << "," <<
-		   triggersFired << "," << 
-		   scaler0 << "," << scaler1 << "," << scaler2 << "," << scaler3 << "," << scaler4 << "," << scaler5 << "," << 
-		   finets0 << "," << finets1 << "," << finets2 << "," << finets3 << "," << finets4 << "," << finets5 << 
+		   triggersFired << "," <<
+		   scaler0 << "," << scaler1 << "," << scaler2 << "," << scaler3 << "," << scaler4 << "," << scaler5 << "," <<
+		   finets0 << "," << finets1 << "," << finets2 << "," << finets3 << "," << finets4 << "," << finets5 <<
 		   std::endl;
       // ev->Print(std::cout);
     }
@@ -118,27 +118,27 @@ int main(int /*argc*/, const char **argv) {
 	  auto timeStampEnd = subev->GetTimestampEnd();
           auto particles = subev->GetTag("PARTICLES", "NAN");
 	  auto triggersFired = subev->GetTag("TRIGGER" , "NAN");
-          auto scaler0 = ev->GetTag("SCALER0", "NAN"); 
-          auto scaler1 = ev->GetTag("SCALER1", "NAN"); 
-          auto scaler2 = ev->GetTag("SCALER2", "NAN");
-          auto scaler3 = ev->GetTag("SCALER3", "NAN");
-          auto scaler4 = ev->GetTag("SCALER4", "NAN");
-          auto scaler5 = ev->GetTag("SCALER5", "NAN");
-          auto finets0 = ev->GetTag("FINE_TS0", "NAN");
-          auto finets1 = ev->GetTag("FINE_TS1", "NAN");
-          auto finets2 = ev->GetTag("FINE_TS2", "NAN");
-          auto finets3 = ev->GetTag("FINE_TS3", "NAN");
-          auto finets4 = ev->GetTag("FINE_TS4", "NAN");
-          auto finets5 = ev->GetTag("FINE_TS5", "NAN");
-          std::cout << runNumber << "," << 
-      		   eventNumber << "," << 
-		   triggerNumber << "," << 
-		   timeStampBegin << "," << 
-		   timeStampEnd << "," << 
+          auto scaler0 = subev->GetTag("SCALER0", "NAN"); 
+          auto scaler1 = subev->GetTag("SCALER1", "NAN"); 
+          auto scaler2 = subev->GetTag("SCALER2", "NAN");
+          auto scaler3 = subev->GetTag("SCALER3", "NAN");
+          auto scaler4 = subev->GetTag("SCALER4", "NAN");
+          auto scaler5 = subev->GetTag("SCALER5", "NAN");
+          auto finets0 = subev->GetTag("FINE_TS0", "NAN");
+          auto finets1 = subev->GetTag("FINE_TS1", "NAN");
+          auto finets2 = subev->GetTag("FINE_TS2", "NAN");
+          auto finets3 = subev->GetTag("FINE_TS3", "NAN");
+          auto finets4 = subev->GetTag("FINE_TS4", "NAN");
+          auto finets5 = subev->GetTag("FINE_TS5", "NAN");
+          std::cout << runNumber << "," <<
+      		   eventNumber << "," <<
+		   triggerNumber << "," <<
+		   timeStampBegin << "," <<
+		   timeStampEnd << "," <<
 		   particles << "," <<
-		   triggersFired << "," << 
-		   scaler0 << "," << scaler1 << "," << scaler2 << "," << scaler3 << "," << scaler4 << "," << scaler5 << "," << 
-		   finets0 << "," << finets1 << "," << finets2 << "," << finets3 << "," << finets4 << "," << finets5 << 
+		   triggersFired << "," <<
+		   scaler0 << "," << scaler1 << "," << scaler2 << "," << scaler3 << "," << scaler4 << "," << scaler5 << "," <<
+		   finets0 << "," << finets1 << "," << finets2 << "," << finets3 << "," << finets4 << "," << finets5 <<
 		   std::endl;
           //subev->Print(std::cout);
           }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -30,11 +30,25 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     d2->SetTag(TLU+stm+"_TRG", std::to_string(d1->GetTriggerN()));
   }
 
+  auto triggersFired = d1->GetTag("TRIGGER" , "NAN");
+  auto finets0 = d1->GetTag("FINE_TS0", "NAN");
+  auto finets1 = d1->GetTag("FINE_TS1", "NAN");
+  auto finets2 = d1->GetTag("FINE_TS2", "NAN");
+  auto finets3 = d1->GetTag("FINE_TS3", "NAN");
+  auto finets4 = d1->GetTag("FINE_TS4", "NAN");
+  auto finets5 = d1->GetTag("FINE_TS5", "NAN");
+
   // Set times for StdEvent in picoseconds (timestamps provided in nanoseconds):
   d2->SetTimeBegin(d1->GetTimestampBegin() * 1000);
   d2->SetTimeEnd(d1->GetTimestampEnd() * 1000);
 
   // Identify the detetor type
   d2->SetDetectorType("TLU");
+  d2->SetTag("FINE_TS0", finets0);
+  d2->SetTag("FINE_TS1", finets1);
+  d2->SetTag("FINE_TS2", finets2);
+  d2->SetTag("FINE_TS3", finets3);
+  d2->SetTag("FINE_TS4", finets4);
+  d2->SetTag("FINE_TS5", finets5);
   return true;
 }


### PR DESCRIPTION
CLICTD Event Converter:
 - place timestamp between shutter open and shutter close

CLICpix2 Event Converter:
 - same

Timepix3 Event Converter:
 - add detector type "SpidrTrigger"
 - add dummy plane containing dummy pixel with trigger input timestamp
 - add explanation of data format

TLU Event Converter:
 - add tags with fine timestamps

euCliReader:
 - correct cout of fine timestamps