### PR TITLE
Choose trigger polarity

### DIFF
--- a/user/tlu/hardware/include/AidaTluController.hh
+++ b/user/tlu/hardware/include/AidaTluController.hh
@@ -36,6 +36,7 @@ namespace tlu {
     //void SetTriggerMask(int value) { SetWRegister("triggerLogic.TriggerMaskW",value); };
     void SetTriggerMask(uint64_t value);
     void SetTriggerMask(uint32_t maskHi, uint32_t maskLo);
+    void SetTriggerPolarity(uint64_t value);
     //void SetTriggerVeto(int value) { SetWRegister("triggerLogic.TriggerVetoW",value); };
     void SetTriggerVeto(int value, uint8_t verbose);
     void SetPulseStretch(int value) { SetWRegister("triggerLogic.PulseStretchW",value); };

--- a/user/tlu/hardware/src/AidaTluController.cc
+++ b/user/tlu/hardware/src/AidaTluController.cc
@@ -1082,8 +1082,8 @@ namespace tlu {
 
   void AidaTluController::SetTriggerPolarity(uint64_t value){
       // The least 6-bits of this register control which edge is used to generate a trigger ( writing '1' reverses the current behaviour ).
-      // '1' -> trigger on rising edge
-      // '0' -> trigger on falling edge (default in firmware)
+      // '1' -> trigger on falling edge
+      // '0' -> trigger on rising edge (default in firmware)
       uint64_t trgPol = (0x3F & value)
       std::cout << std::hex << "  TRIGGER POLARITY (for external triggers) SET TO 0x" << trgPol << std::dec << std::endl;
       SetWRegister("triggerInputs.InvertEdgeW", trgPol);

--- a/user/tlu/hardware/src/AidaTluController.cc
+++ b/user/tlu/hardware/src/AidaTluController.cc
@@ -1080,6 +1080,15 @@ namespace tlu {
     SetWRegister("triggerLogic.TriggerPattern_highW", maskHi);
   }
 
+  void AidaTluController::SetTriggerPolarity(uint64_t value){
+      // The least 6-bits of this register control which edge is used to generate a trigger ( writing '1' reverses the current behaviour ).
+      // '1' -> trigger on rising edge
+      // '0' -> trigger on falling edge (default in firmware)
+      uint64_t trgPol = (0x3F & value)
+      std::cout << std::hex << "  TRIGGER POLARITY (for external triggers) SET TO 0x" << trgPol << std::dec << std::endl;
+      SetWRegister("triggerInputs.InvertEdgeW", trgPol);
+  }
+
   void AidaTluController::SetTriggerVeto(int value, uint8_t verbose){
     uint32_t vetoStatus;
     SetWRegister("triggerLogic.TriggerVetoW",value);

--- a/user/tlu/module/src/AidaTluProducer.cc
+++ b/user/tlu/module/src/AidaTluProducer.cc
@@ -263,6 +263,10 @@ void AidaTluProducer::DoConfigure() {
     if(m_verbose > 0) EUDAQ_INFO(" -DEFINE TRIGGER MASK");
     m_tlu->SetTriggerMask( (uint32_t)(conf->Get("trigMaskHi", 0xFFFF)),  (uint32_t)(conf->Get("trigMaskLo", 0xFFFE)) );
 
+    // Set triggerPolarity
+    if(m_verbose > 0) EUDAQ_INFO(" -DEFINE TRIGGER POLARITY");
+    m_tlu->SetTriggerPolarity( (uint64_t)(conf->Get("trigPol", 0x003F));
+
     // Set PMT power
     if(m_verbose > 0) EUDAQ_INFO(" -PMT OUTPUT VOLTAGES");
     m_tlu->pwrled_setVoltages(conf->Get("PMT1_V", 0.0), conf->Get("PMT2_V", 0.0), conf->Get("PMT3_V", 0.0), conf->Get("PMT4_V", 0.0), m_verbose);


### PR DESCRIPTION
This MR implements a new function in the AidaTluController to set the register in the FPGA to choose the trigger polarity.
