### PR TITLE
Set precise trigger ts

### DIFF
--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -37,9 +37,6 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   auto finets4 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
   auto finets5 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
 
-  std::cout << "triggersFired (stoi) = " << triggersFired << std::endl;
-  std::cout << "triggerFired GetTag = " << d1->GetTag("TRIGGER" , "NAN") << std::endl;
-
   // Set times for StdEvent in picoseconds (timestamps provided in nanoseconds):
   // Note: __builtin_popcount counts the "ones" in a binary, see here:
   // https://www.geeksforgeeks.org/count-set-bits-in-an-integer/

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -31,11 +31,11 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
   auto triggersFired = std::stoi(d1->GetTag("TRIGGER" , "NAN"), nullptr, 2); // interpret as binary
   auto finets0 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
-  auto finets1 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
-  auto finets2 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
-  auto finets3 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
-  auto finets4 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
-  auto finets5 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
+  auto finets1 = std::stoi(d1->GetTag("FINE_TS1", "NAN"));
+  auto finets2 = std::stoi(d1->GetTag("FINE_TS2", "NAN"));
+  auto finets3 = std::stoi(d1->GetTag("FINE_TS3", "NAN"));
+  auto finets4 = std::stoi(d1->GetTag("FINE_TS4", "NAN"));
+  auto finets5 = std::stoi(d1->GetTag("FINE_TS5", "NAN"));
 
   // Set times for StdEvent in picoseconds (timestamps provided in nanoseconds):
   // Note: __builtin_popcount counts the "ones" in a binary, see here:

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -48,7 +48,7 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
                + (finets3 * ((triggersFired >> 3) & 0x1))
                + (finets4 * ((triggersFired >> 4) & 0x1))
                + (finets5 * ((triggersFired >> 5) & 0x1)))
-               / __builtin_popcount(triggersFired); // count "ones" in binary
+               / __builtin_popcount(triggersFired & 0x3F); // count "ones" in binary
 
   auto ts = (d1->GetTimestampBegin() * 1000) & 0xFFFFFFFFFFFFFF00 + static_cast<uint64_t>(25. / 32. * finets);
 

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -29,13 +29,13 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     d2->SetTag(TLU+stm+"_TRG", std::to_string(d1->GetTriggerN()));
   }
 
-  auto triggersFired = std::stoi(d1->GetTag("TRIGGER" , "NAN"), nullptr, 2); // interpret as binary
-  auto finets0 = std::stoi(d1->GetTag("FINE_TS0", "NAN"));
-  auto finets1 = std::stoi(d1->GetTag("FINE_TS1", "NAN"));
-  auto finets2 = std::stoi(d1->GetTag("FINE_TS2", "NAN"));
-  auto finets3 = std::stoi(d1->GetTag("FINE_TS3", "NAN"));
-  auto finets4 = std::stoi(d1->GetTag("FINE_TS4", "NAN"));
-  auto finets5 = std::stoi(d1->GetTag("FINE_TS5", "NAN"));
+  auto triggersFired = std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
+  auto finets0 = std::stoi(d1->GetTag("FINE_TS0", "0"));
+  auto finets1 = std::stoi(d1->GetTag("FINE_TS1", "0"));
+  auto finets2 = std::stoi(d1->GetTag("FINE_TS2", "0"));
+  auto finets3 = std::stoi(d1->GetTag("FINE_TS3", "0"));
+  auto finets4 = std::stoi(d1->GetTag("FINE_TS4", "0"));
+  auto finets5 = std::stoi(d1->GetTag("FINE_TS5", "0"));
 
   // Set times for StdEvent in picoseconds (timestamps provided in nanoseconds):
   // Note: __builtin_popcount counts the "ones" in a binary, see here:


### PR DESCRIPTION
Calculate the precise trigger ts by combining the coarse and the average of all available fine timestamps.