### PR TITLE
Correctly combine fine TS from TLU

### DIFF
--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -139,8 +139,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         // Hence, if the current timestamp is more than 20us earlier than the previous timestamp, we can assume that
         // a 2nd T0 has occured. Take 500us with some safety margin.
         // This implies we cannot detect a 2nd T0 within the first 500us after the initial T0. But did this ever happen?
-      // } else if (m_syncTime < m_syncTime_prev - (500 * 4096 * 40)) {
-      } else if (m_syncTime < m_syncTime_prev - (1e6 * 4096 * 40)) { // 1 sec
+      } else if (m_syncTime < m_syncTime_prev - (1e6 * 4096 * 40)) {
           m_clearedHeader++;
         }
         m_syncTime_prev = m_syncTime;

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -73,7 +73,6 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   d2->SetTimeEnd(triggerTime);
 
   // Identify the detetor type
-  // std::cout << "Found SpidrTrigger at timestamp = " << std::setprecision(9) << triggerTime/1e12 << "s" << std::endl;
   d2->SetDetectorType("SpidrTrigger");
 
   return true;
@@ -130,8 +129,6 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       if(header2 == 0x5) {
         // The data is shifted 16 bits to the right, then 44 to the left in order to match the timestamp format (net 28 left)
         m_syncTime = (m_syncTime & 0x00000FFFFFFFFFFF) + ((pixdata & 0x00000000FFFF0000) << 28);
-
-        // std::cout << "m_syncTime = " << m_syncTime/4096/40/1e6 << ", m_syncTime_prev = " << m_syncTime_prev/4096/40/1e6 << std::endl;
 
         if(m_clearedHeader==0 && (m_syncTime / 4096 / 40) < 6000000) { // < 6sec
           EUDAQ_INFO("Detected T0 signal. Header cleared.");
@@ -210,7 +207,6 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
   d2->SetTimeEnd(event_end);
 
   // Identify the detetor type
-  // std::cout << "Timepix3 data at timestamp " << std::setprecision(9) << event_begin/1e12 << "s" << std::endl;
   d2->SetDetectorType("Timepix3");
 
   return data_found;

--- a/user/tlu/README.md
+++ b/user/tlu/README.md
@@ -44,4 +44,4 @@ The usage with EUDAQ2 and EUDET-type telescopes is described [here](https://tele
 The conversion of raw data containing **TluRawDataEvent** is the same for both types of TLU. For example and if LCIO is built, you can convert by: ```euCliConverter -i data.raw -o data.slcio```
 The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
-* `tof_scint0`, `tof_scint1`, ..., `tof_scint5`: Time-of-flight of the i-th scintillator in nanoseconds as double. This value is rounded to 781.25ps bins and subtracted from the fine timestamp of the i-th scintillator. Defaults to `0` (pass value without units). Please note that the most upstream scintillator should have a time-of-flight of zero.
+* `delay_scint0`, `delay_scint1`, ..., `delay_scint5`: Delay (time-of-flight + cable delays) of the i-th scintillator in 781.25ps bins as integer. This value is subtracted from the fine timestamp of the i-th scintillator in order to calculate the correct precise TLU trigger timestamp. Defaults to `0`. Please note that the most upstream scintillator should have a delay of zero.

--- a/user/tlu/README.md
+++ b/user/tlu/README.md
@@ -42,6 +42,11 @@ The usage with EUDAQ2 and EUDET-type telescopes is described [here](https://tele
 ## Conversion
 
 The conversion of raw data containing **TluRawDataEvent** is the same for both types of TLU. For example and if LCIO is built, you can convert by: ```euCliConverter -i data.raw -o data.slcio```
+The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
-
-
+* `tof_scint0`: Double time-of-flight of the 0th scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 0th scintillator. Defaults to `0` (pass only value without units).
+* `tof_scint1`: Double time-of-flight of the 1st scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 1st scintillator. Defaults to `0` (pass only value without units).
+* `tof_scint2`: Double time-of-flight of the 2nd scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 2nd scintillator. Defaults to `0` (pass only value without units).
+* `tof_scint3`: Double time-of-flight of the 3rd scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 3rd scintillator. Defaults to `0` (pass only value without units).
+* `tof_scint4`: Double time-of-flight of the 4th scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 4th scintillator. Defaults to `0` (pass only value without units).
+* `tof_scint5`: Double time-of-flight of the 5th scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 5th scintillator. Defaults to `0` (pass only value without units).

--- a/user/tlu/README.md
+++ b/user/tlu/README.md
@@ -45,3 +45,9 @@ The conversion of raw data containing **TluRawDataEvent** is the same for both t
 The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
 * `delay_scint0`, `delay_scint1`, ..., `delay_scint5`: Delay (time-of-flight + cable delays) of the i-th scintillator in 781.25ps bins as integer. This value is subtracted from the fine timestamp of the i-th scintillator in order to calculate the correct precise TLU trigger timestamp. Defaults to `0`. Please note that the most upstream scintillator should have a delay of zero.
+
+The following flags are forwarded directly from the raw event to the standard event:
+* `FINE_TS0`, `FINE_TS1`, ..., `FINE_TS5`: Fine timestamp of the i-th scintillator in 781.25ps bins.
+
+The following flags are added in addition the the standard event:
+* `DIFF_FINETS01_del_ns`, ..., `DIFF_FINETS45_del_ns`: Difference of the i-th and the j-th scinitllator timestamp converted into nanoseconds and including the delay values provided by `delay_scint0` etc.

--- a/user/tlu/README.md
+++ b/user/tlu/README.md
@@ -44,9 +44,4 @@ The usage with EUDAQ2 and EUDET-type telescopes is described [here](https://tele
 The conversion of raw data containing **TluRawDataEvent** is the same for both types of TLU. For example and if LCIO is built, you can convert by: ```euCliConverter -i data.raw -o data.slcio```
 The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
-* `tof_scint0`: Double time-of-flight of the 0th scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 0th scintillator. Defaults to `0` (pass only value without units).
-* `tof_scint1`: Double time-of-flight of the 1st scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 1st scintillator. Defaults to `0` (pass only value without units).
-* `tof_scint2`: Double time-of-flight of the 2nd scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 2nd scintillator. Defaults to `0` (pass only value without units).
-* `tof_scint3`: Double time-of-flight of the 3rd scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 3rd scintillator. Defaults to `0` (pass only value without units).
-* `tof_scint4`: Double time-of-flight of the 4th scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 4th scintillator. Defaults to `0` (pass only value without units).
-* `tof_scint5`: Double time-of-flight of the 5th scintillator in nanoseconds. This value is rounded into 781.125ps bins and added to the fine timestamp of the 5th scintillator. Defaults to `0` (pass only value without units).
+* `tof_scint0`, `tof_scint1`, ..., `tof_scint5`: Time-of-flight of the i-th scintillator in nanoseconds as double. This value is rounded to 781.25ps bins and subtracted from the fine timestamp of the i-th scintillator. Defaults to `0` (pass value without units). Please note that the most upstream scintillator should have a time-of-flight of zero.

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -143,11 +143,11 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   // Identify the detetor type
   d2->SetDetectorType("TLU");
   d2->SetTag("TRIGGER", triggersFired);
-  d2->SetTag("FINE_TS0", d1->GetTag("FINE_TS0", "0"));
-  d2->SetTag("FINE_TS1", d1->GetTag("FINE_TS1", "0"));
-  d2->SetTag("FINE_TS2", d1->GetTag("FINE_TS2", "0"));
-  d2->SetTag("FINE_TS3", d1->GetTag("FINE_TS3", "0"));
-  d2->SetTag("FINE_TS4", d1->GetTag("FINE_TS4", "0"));
-  d2->SetTag("FINE_TS5", d1->GetTag("FINE_TS5", "0"));
+  d2->SetTag("FINE_TS0", std::to_string(finets0 & 0xFF).c_str());
+  d2->SetTag("FINE_TS1", std::to_string(finets1 & 0xFF).c_str());
+  d2->SetTag("FINE_TS2", std::to_string(finets2 & 0xFF).c_str());
+  d2->SetTag("FINE_TS3", std::to_string(finets3 & 0xFF).c_str());
+  d2->SetTag("FINE_TS4", std::to_string(finets4 & 0xFF).c_str());
+  d2->SetTag("FINE_TS5", std::to_string(finets5 & 0xFF).c_str());
   return true;
 }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -39,7 +39,7 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   try {
     triggersFired = 0x3F & std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
   } catch (...) {
-    EUDAQ_WARN("Event flag TRIGGER cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
+    EUDAQ_WARN("EUDAQ2 RawEvent flag TRIGGER cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
     return false;
   }
   try {
@@ -50,7 +50,7 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     finets4 = std::stoi(d1->GetTag("FINE_TS4", "0"));
     finets5 = std::stoi(d1->GetTag("FINE_TS5", "0"));
 } catch (...) {
-    EUDAQ_WARN("Event flag FINE_TS<0-5> cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
+    EUDAQ_WARN("EUDAQ2 RawEvent flag FINE_TS<0-5> cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
     return false;
 }
 

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -29,13 +29,30 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     d2->SetTag(TLU+stm+"_TRG", std::to_string(d1->GetTriggerN()));
   }
 
-  auto triggersFired = std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
-  auto finets0 = std::stoi(d1->GetTag("FINE_TS0", "0"));
-  auto finets1 = std::stoi(d1->GetTag("FINE_TS1", "0"));
-  auto finets2 = std::stoi(d1->GetTag("FINE_TS2", "0"));
-  auto finets3 = std::stoi(d1->GetTag("FINE_TS3", "0"));
-  auto finets4 = std::stoi(d1->GetTag("FINE_TS4", "0"));
-  auto finets5 = std::stoi(d1->GetTag("FINE_TS5", "0"));
+  uint8_t triggersFired;
+  uint32_t finets0;
+  uint32_t finets1;
+  uint32_t finets2;
+  uint32_t finets3;
+  uint32_t finets4;
+  uint32_t finets5;
+  try {
+    triggersFired = 0x3F & std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
+  } catch (...) {
+    EUDAQ_WARN("Event flag TRIGGER cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
+    return false;
+  }
+  try {
+    finets0 = std::stoi(d1->GetTag("FINE_TS0", "0"));
+    finets1 = std::stoi(d1->GetTag("FINE_TS1", "0"));
+    finets2 = std::stoi(d1->GetTag("FINE_TS2", "0"));
+    finets3 = std::stoi(d1->GetTag("FINE_TS3", "0"));
+    finets4 = std::stoi(d1->GetTag("FINE_TS4", "0"));
+    finets5 = std::stoi(d1->GetTag("FINE_TS5", "0"));
+} catch (...) {
+    EUDAQ_WARN("Event flag FINE_TS<0-5> cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
+    return false;
+}
 
   // add all valid trigger to vector:
   std::vector<uint8_t> finets_vec;

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -45,7 +45,6 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   double tof_scint3 = conf->Get("tof_scint3", 1.); // in nanoseconds
   double tof_scint4 = conf->Get("tof_scint4", 1.); // in nanoseconds
   double tof_scint5 = conf->Get("tof_scint5", 1.); // in nanoseconds
-  // EUDAQ_WARN("Using finets0_tof = " + std::to_string(tof_scint0));
   try {
     triggersFired = 0x3F & std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
   } catch (...) {

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -112,7 +112,7 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
   // Casting to 32 bit is essential to detect the overflow in the 8th bit!
   // 0x100 = 200ns (range of 3 bits with 25ns binning)
-  if((static_cast<uint32_t>(coarse_3lsb - finets_avg_3msb)) > 0x100) {
+  if((static_cast<uint32_t>(coarse_3lsb) - finets_avg_3msb) > 0x100) {
       // coarse_ts is delayed by 2 clock cycles -> roll back
       coarse_ts -= 2;
   }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -1,6 +1,5 @@
 #include "eudaq/StdEventConverter.hh"
 #include "eudaq/RawEvent.hh"
-#include <cmath> // for round()
 
 class TluRawEvent2StdEventConverter: public eudaq::StdEventConverter{
 public:

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -127,7 +127,6 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
   // Identify the detetor type
   d2->SetDetectorType("TLU");
-  d2->SetTag("TRIGGER", triggersFired);
   d2->SetTag("TRIGGER", d1->GetTag("TRIGGER" , "0"));
 
   // forward original tags:

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -39,12 +39,12 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   uint32_t finets5;
 
   // Should I read these in at m_first_time and store in static member variable or read in each time?
-  double tof_scint0 = conf->Get("tof_scint0", 1.); // in nanoseconds
-  double tof_scint1 = conf->Get("tof_scint1", 1.); // in nanoseconds
-  double tof_scint2 = conf->Get("tof_scint2", 1.); // in nanoseconds
-  double tof_scint3 = conf->Get("tof_scint3", 1.); // in nanoseconds
-  double tof_scint4 = conf->Get("tof_scint4", 1.); // in nanoseconds
-  double tof_scint5 = conf->Get("tof_scint5", 1.); // in nanoseconds
+  double tof_scint0 = conf->Get("tof_scint0", 0.); // in nanoseconds
+  double tof_scint1 = conf->Get("tof_scint1", 0.); // in nanoseconds
+  double tof_scint2 = conf->Get("tof_scint2", 0.); // in nanoseconds
+  double tof_scint3 = conf->Get("tof_scint3", 0.); // in nanoseconds
+  double tof_scint4 = conf->Get("tof_scint4", 0.); // in nanoseconds
+  double tof_scint5 = conf->Get("tof_scint5", 0.); // in nanoseconds
   try {
     triggersFired = 0x3F & std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
   } catch (...) {

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -51,8 +51,9 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     EUDAQ_WARN("EUDAQ2 RawEvent flag TRIGGER cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
     return false;
   }
+
+  // try/catch for std::stoi()
   try {
-    // try/catch for std::stoi()
     // Subtract delay from fine timestamp:
     finets0 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS0", "0"))) - delay_scint0;
     finets1 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS1", "0"))) - delay_scint1;
@@ -102,23 +103,8 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
       finets_avg = ((i*finets_avg + finets_vec.at(i)) / (i+1));
 
       // This leads to rounding errors on the 781ps binning level
-      // --> Convert to double in nanoseconds?
+      // but otherwise the overflow detection logic breaks down.
   }
-
-  /*
-  // This works well: using ONLY fineTS0 OR fineTS1:
-  auto finets_avg = finets0;
-  auto finets_avg = finets1;
-  */
-
-  /*
-  // This also works well (only for 2 inputs):
-  // Consider overflow:
-  if(abs(finets0 - finets1) > 0xF0) {
-      finets1 += 0xFF;
-  }
-  finets_avg = 0xFF & ((finets0 + finets1) / 2);
-  */
 
   auto coarse_ts = static_cast<uint64_t>(d1->GetTimestampBegin() / 25);
 

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -52,12 +52,14 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     return false;
   }
   try {
-    finets0 = std::stoi(d1->GetTag("FINE_TS0", "0")) + static_cast<uint32_t>(round(tof_scint0 / 0.78125)); // convert into 781.25ps bins and round
-    finets1 = std::stoi(d1->GetTag("FINE_TS1", "0")) + static_cast<uint32_t>(round(tof_scint1 / 0.78125)); // convert into 781.25ps bins and round
-    finets2 = std::stoi(d1->GetTag("FINE_TS2", "0")) + static_cast<uint32_t>(round(tof_scint2 / 0.78125)); // convert into 781.25ps bins and round
-    finets3 = std::stoi(d1->GetTag("FINE_TS3", "0")) + static_cast<uint32_t>(round(tof_scint3 / 0.78125)); // convert into 781.25ps bins and round
-    finets4 = std::stoi(d1->GetTag("FINE_TS4", "0")) + static_cast<uint32_t>(round(tof_scint4 / 0.78125)); // convert into 781.25ps bins and round
-    finets5 = std::stoi(d1->GetTag("FINE_TS5", "0")) + static_cast<uint32_t>(round(tof_scint5 / 0.78125)); // convert into 781.25ps bins and round
+    // try/catch for std::stoi()
+    // Convert TOF into 781.25ps bins and round to integer, then subtract from fine timestamp:
+    finets0 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS0", "0"))) - static_cast<uint32_t>(round(tof_scint0 / 0.78125));
+    finets1 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS1", "0"))) - static_cast<uint32_t>(round(tof_scint1 / 0.78125));
+    finets2 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS2", "0"))) - static_cast<uint32_t>(round(tof_scint2 / 0.78125));
+    finets3 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS3", "0"))) - static_cast<uint32_t>(round(tof_scint3 / 0.78125));
+    finets4 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS4", "0"))) - static_cast<uint32_t>(round(tof_scint4 / 0.78125));
+    finets5 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS5", "0"))) - static_cast<uint32_t>(round(tof_scint5 / 0.78125));
 } catch (...) {
     EUDAQ_WARN("EUDAQ2 RawEvent flag FINE_TS<0-5> cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
     return false;

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -1,6 +1,5 @@
 #include "eudaq/StdEventConverter.hh"
 #include "eudaq/RawEvent.hh"
-#include <bitset>
 
 class TluRawEvent2StdEventConverter: public eudaq::StdEventConverter{
 public:
@@ -31,9 +30,6 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   }
 
   auto triggersFired = std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
-  auto nTriggerInputs = __builtin_popcount(triggersFired & 0x3F); // count "ones" in binary
-  // Note: __builtin_popcount counts the "ones" in a binary, see here:
-  // https://www.geeksforgeeks.org/count-set-bits-in-an-integer/
   auto finets0 = std::stoi(d1->GetTag("FINE_TS0", "0"));
   auto finets1 = std::stoi(d1->GetTag("FINE_TS1", "0"));
   auto finets2 = std::stoi(d1->GetTag("FINE_TS2", "0"));

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -141,10 +141,10 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   // calculate (delayed) fine timestamps in ns:
   double finets0_ns = (finets0 & 0xFF) * 25. / 32.; // 781ps binning
   double finets1_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
-  double finets2_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
-  double finets3_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
-  double finets4_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
-  double finets5_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets2_ns = (finets2 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets3_ns = (finets3 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets4_ns = (finets4 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets5_ns = (finets5 & 0xFF) * 25. / 32.; // 781ps binning
 
   // differences between (delayed) fine timestamps:
   d2->SetTag("DIFF_FINETS01_del_ns", std::to_string((finets0_ns - finets1_ns)).c_str());

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -119,8 +119,5 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   d2->SetTag("FINE_TS3", finets3);
   d2->SetTag("FINE_TS4", finets4);
   d2->SetTag("FINE_TS5", finets5);
-  // if(d1->IsFlagTrigger()) {
-  //     std::cout << "TLU trigger number: " << d1->GetTriggerN() << std::endl;
-  // }
   return true;
 }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -94,8 +94,6 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   for(int i=1; i<finets_vec.size(); i++) {
       // 128 = half the fineTS counter range -> 128*780ps = 99ns = 3m (TOF)
       // For a time difference larger than 99ns, the overflow detection doesn't work anymore.
-      // If the delay (TOF/cabling) between scintillators exceeds 99ns, the TOFs should be
-      // specified as input parameters for correction.
       if(abs(finets_avg - finets_vec.at(i)) > 128) { // 128*780ps = 99ns
           finets_vec.at(i) += 0xFF; // overflow compensation
       }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -128,11 +128,44 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   // Identify the detetor type
   d2->SetDetectorType("TLU");
   d2->SetTag("TRIGGER", triggersFired);
-  d2->SetTag("FINE_TS0", std::to_string(finets0 & 0xFF).c_str());
-  d2->SetTag("FINE_TS1", std::to_string(finets1 & 0xFF).c_str());
-  d2->SetTag("FINE_TS2", std::to_string(finets2 & 0xFF).c_str());
-  d2->SetTag("FINE_TS3", std::to_string(finets3 & 0xFF).c_str());
-  d2->SetTag("FINE_TS4", std::to_string(finets4 & 0xFF).c_str());
-  d2->SetTag("FINE_TS5", std::to_string(finets5 & 0xFF).c_str());
+  d2->SetTag("TRIGGER", d1->GetTag("TRIGGER" , "0"));
+
+  // forward original tags:
+  d2->SetTag("FINE_TS0", d1->GetTag("FINE_TS0", "0")); // forward original tag
+  d2->SetTag("FINE_TS1", d1->GetTag("FINE_TS1", "0")); // forward original tag
+  d2->SetTag("FINE_TS2", d1->GetTag("FINE_TS2", "0")); // forward original tag
+  d2->SetTag("FINE_TS3", d1->GetTag("FINE_TS3", "0")); // forward original tag
+  d2->SetTag("FINE_TS4", d1->GetTag("FINE_TS4", "0")); // forward original tag
+  d2->SetTag("FINE_TS5", d1->GetTag("FINE_TS5", "0")); // forward original tag
+
+  // calculate (delayed) fine timestamps in ns:
+  double finets0_ns = (finets0 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets1_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets2_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets3_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets4_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
+  double finets5_ns = (finets1 & 0xFF) * 25. / 32.; // 781ps binning
+
+  // differences between (delayed) fine timestamps:
+  d2->SetTag("DIFF_FINETS01_del_ns", std::to_string((finets0_ns - finets1_ns)).c_str());
+  d2->SetTag("DIFF_FINETS02_del_ns", std::to_string((finets0_ns - finets2_ns)).c_str());
+  d2->SetTag("DIFF_FINETS03_del_ns", std::to_string((finets0_ns - finets3_ns)).c_str());
+  d2->SetTag("DIFF_FINETS04_del_ns", std::to_string((finets0_ns - finets4_ns)).c_str());
+  d2->SetTag("DIFF_FINETS05_del_ns", std::to_string((finets0_ns - finets5_ns)).c_str());
+
+  d2->SetTag("DIFF_FINETS12_del_ns", std::to_string((finets1_ns - finets2_ns)).c_str());
+  d2->SetTag("DIFF_FINETS13_del_ns", std::to_string((finets1_ns - finets3_ns)).c_str());
+  d2->SetTag("DIFF_FINETS14_del_ns", std::to_string((finets1_ns - finets4_ns)).c_str());
+  d2->SetTag("DIFF_FINETS15_del_ns", std::to_string((finets1_ns - finets5_ns)).c_str());
+
+  d2->SetTag("DIFF_FINETS23_del_ns", std::to_string((finets3_ns - finets3_ns)).c_str());
+  d2->SetTag("DIFF_FINETS24_del_ns", std::to_string((finets3_ns - finets4_ns)).c_str());
+  d2->SetTag("DIFF_FINETS25_del_ns", std::to_string((finets3_ns - finets5_ns)).c_str());
+
+  d2->SetTag("DIFF_FINETS34_del_ns", std::to_string((finets4_ns - finets4_ns)).c_str());
+  d2->SetTag("DIFF_FINETS35_del_ns", std::to_string((finets4_ns - finets5_ns)).c_str());
+
+  d2->SetTag("DIFF_FINETS45_del_ns", std::to_string((finets5_ns - finets5_ns)).c_str());
+
   return true;
 }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -145,11 +145,11 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   // Identify the detetor type
   d2->SetDetectorType("TLU");
   d2->SetTag("TRIGGER", triggersFired);
-  d2->SetTag("FINE_TS0", finets0);
-  d2->SetTag("FINE_TS1", finets1);
-  d2->SetTag("FINE_TS2", finets2);
-  d2->SetTag("FINE_TS3", finets3);
-  d2->SetTag("FINE_TS4", finets4);
-  d2->SetTag("FINE_TS5", finets5);
+  d2->SetTag("FINE_TS0", d1->GetTag("FINE_TS0", "0"));
+  d2->SetTag("FINE_TS1", d1->GetTag("FINE_TS1", "0"));
+  d2->SetTag("FINE_TS2", d1->GetTag("FINE_TS2", "0"));
+  d2->SetTag("FINE_TS3", d1->GetTag("FINE_TS3", "0"));
+  d2->SetTag("FINE_TS4", d1->GetTag("FINE_TS4", "0"));
+  d2->SetTag("FINE_TS5", d1->GetTag("FINE_TS5", "0"));
   return true;
 }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -127,7 +127,7 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
   // Casting to 32 bit is essential to detect the overflow in the 8th bit!
   // 0x100 = 200ns (range of 3 bits with 25ns binning)
-  if(static_cast<uint32_t>(coarse_3lsb - finets_avg_3msb) > 0x100) {
+  if((static_cast<uint32_t>(coarse_3lsb - finets_avg_3msb)) > 0x100) {
       // coarse_ts is delayed by 2 clock cycles -> roll back
       coarse_ts -= 2;
   }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -39,12 +39,12 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   uint32_t finets5;
 
   // Should I read these in at m_first_time and store in static member variable or read in each time?
-  double tof_scint0 = conf->Get("tof_scint0", 0.); // in nanoseconds
-  double tof_scint1 = conf->Get("tof_scint1", 0.); // in nanoseconds
-  double tof_scint2 = conf->Get("tof_scint2", 0.); // in nanoseconds
-  double tof_scint3 = conf->Get("tof_scint3", 0.); // in nanoseconds
-  double tof_scint4 = conf->Get("tof_scint4", 0.); // in nanoseconds
-  double tof_scint5 = conf->Get("tof_scint5", 0.); // in nanoseconds
+  uint32_t delay_scint0 = conf->Get("delay_scint0", 0); // in 781.25ps bins
+  uint32_t delay_scint1 = conf->Get("delay_scint1", 0); // in 781.25ps bins
+  uint32_t delay_scint2 = conf->Get("delay_scint2", 0); // in 781.25ps bins
+  uint32_t delay_scint3 = conf->Get("delay_scint3", 0); // in 781.25ps bins
+  uint32_t delay_scint4 = conf->Get("delay_scint4", 0); // in 781.25ps bins
+  uint32_t delay_scint5 = conf->Get("delay_scint5", 0); // in 781.25ps bins
   try {
     triggersFired = 0x3F & std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
   } catch (...) {
@@ -53,13 +53,13 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   }
   try {
     // try/catch for std::stoi()
-    // Convert TOF into 781.25ps bins and round to integer, then subtract from fine timestamp:
-    finets0 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS0", "0"))) - static_cast<uint32_t>(round(tof_scint0 / 0.78125));
-    finets1 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS1", "0"))) - static_cast<uint32_t>(round(tof_scint1 / 0.78125));
-    finets2 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS2", "0"))) - static_cast<uint32_t>(round(tof_scint2 / 0.78125));
-    finets3 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS3", "0"))) - static_cast<uint32_t>(round(tof_scint3 / 0.78125));
-    finets4 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS4", "0"))) - static_cast<uint32_t>(round(tof_scint4 / 0.78125));
-    finets5 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS5", "0"))) - static_cast<uint32_t>(round(tof_scint5 / 0.78125));
+    // Subtract delay from fine timestamp:
+    finets0 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS0", "0"))) - delay_scint0;
+    finets1 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS1", "0"))) - delay_scint1;
+    finets2 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS2", "0"))) - delay_scint2;
+    finets3 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS3", "0"))) - delay_scint3;
+    finets4 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS4", "0"))) - delay_scint4;
+    finets5 = static_cast<uint32_t>(std::stoi(d1->GetTag("FINE_TS5", "0"))) - delay_scint5;
 } catch (...) {
     EUDAQ_WARN("EUDAQ2 RawEvent flag FINE_TS<0-5> cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
     return false;

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -64,6 +64,11 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   if(finets_vec.size() < 2) {
       std::cout << "ERROR: received less than 2 trigger inputs" << std::endl;
       return false;
+
+      // or throw exception:
+      throw eudaq::DataInvalid("Received less than 2 trigger inputs.");
+
+      // or is that even fine to have only one trigger input???
   }
 
   // Now average over all vector elements:
@@ -75,8 +80,12 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
       if(abs(finets_avg - finets_vec.at(i)) > 0xF0) {
           finets_avg += 0xFF; // overflow compensation
       }
-      finets_avg += finets_vec.at(i);
-      finets_avg = (finets_avg / 2) & 0xFF;
+      // Need to weight average with previous number of iterations:
+      finets_avg = ((i*finets_avg + finets_vec.at(i)) / (i+1)) & 0xFF;
+
+      // finets_avg += finets_vec.at(i);
+      // finets_avg = (finets_avg / 2) & 0xFF;
+
       // This leads to rounding errors on the 781ps binning level
       // --> Convert to double in nanoseconds?
   }

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -61,15 +61,6 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   if ((triggersFired >> 5) & 0x1) {
       finets_vec.emplace_back(finets5 & 0xFF);
   }
-  if(finets_vec.size() < 2) {
-      std::cout << "ERROR: received less than 2 trigger inputs" << std::endl;
-      return false;
-
-      // or throw exception:
-      throw eudaq::DataInvalid("Received less than 2 trigger inputs.");
-
-      // or is that even fine to have only one trigger input???
-  }
 
   // Now average over all vector elements:
   // Initialize to 0th vector element:

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -82,8 +82,8 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   }
 
   // This works well: using ONLY fineTS0 OR fineTS1:
-  // auto finets = finets0;
-  // auto finets = finets1;
+  // auto finets_avg = finets0;
+  // auto finets_avg = finets1;
 
   // This also works well:
   // Consider overflow:

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -77,6 +77,8 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
       }
       finets_avg += finets_vec.at(i);
       finets_avg = (finets_avg / 2) & 0xFF;
+      // This leads to rounding errors on the 781ps binning level
+      // --> Convert to double in nanoseconds?
   }
 
   // This works well: using ONLY fineTS0 OR fineTS1:


### PR DESCRIPTION
This MR contains changes in order to correctly combine the fine timestamps from the TLU to get the precise timestamp with 780 ps binning, solving the issue with the overflow of the counter (side peaks in time residuals).

Tested for 2 trigger inputs.

**Plan:** take data with 3-4 trigger inputs at DESY in July 2020 and then test other combinations as well.

**WIP** because not yet cleaned/fully tested.

Please comment on current implementation.