### PR TITLE
Add Timepix3 Calibration

### DIFF
--- a/user/timepix3/README.md
+++ b/user/timepix3/README.md
@@ -28,6 +28,8 @@ Since the SPIDR device libraries are not thread-safe, all access to SPIDR librar
 The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
 * `delta_t0`: Integer in microseconds as the criterion for the indirect T0 detection. If the Timepix3 timestamps jump back by more than this value, a 2nd T0 is assumed to have been recorded. The value needs to be passed as an integer without units, but a syntax such as `1e3` is supported. Defaults to `1e6` (corresponding to 1s).
+* `calibration_path_tot`: Path to ToT calibration file. If this parameter is set, a conversion of the pixel time-over-threshold values to charge is applied. The file format needs to be `col | row | row | a (ADC/mV) | b (ADC) | c (ADC*mV) | t (mV) | chi2/ndf`.
+* `calibration_path_toa`: Path to ToA calibration file. If this parameter is set, a timewalk correction is applied to each pixel timestamp. The file format needs to be `column | row | c (ns*mV) | t (mV) | d (ns) | chi2/ndf`.
 
 ### Timepix3TrigEvent2StdEventConverter
 

--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -19,8 +19,6 @@ namespace eudaq {
     // configuration parameters:
     static bool m_first_time;
     static bool applyCalibration;
-    static std::string calibrationPathToT;
-    static std::string calibrationPathToA;
     static std::vector<std::vector<float>> vtot;
     static std::vector<std::vector<float>> vtoa;
 

--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -19,9 +19,8 @@ namespace eudaq {
     // configuration parameters:
     static bool m_first_time;
     static bool applyCalibration;
-    static std::string calibrateDetector;
-    static std::string calibrationPath;
-    static std::string threshold;
+    static std::string calibrationPathToT;
+    static std::string calibrationPathToA;
     static std::vector<std::vector<float>> vtot;
     static std::vector<std::vector<float>> vtoa;
 

--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -16,7 +16,6 @@ namespace eudaq {
     static uint64_t m_syncTime_prev;
     static bool m_clearedHeader;
     static bool m_first_time;
-    static bool applyCalibration;
     static std::vector<std::vector<float>> vtot;
     static std::vector<std::vector<float>> vtoa;
 

--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -14,6 +14,17 @@ namespace eudaq {
   private:
     static uint64_t m_syncTime;
     static bool m_clearedHeader;
+
+    // configuration parameters:
+    static bool first_time;     // How to avoid this with an Initialize() function?
+    static bool applyCalibration;
+    static std::string calibrateDetector;
+    static std::string calibrationPath;
+    static std::string threshold;
+    static std::vector<std::vector<float>> vtot;
+    static std::vector<std::vector<float>> vtoa;
+
+    void loadCalibration(std::string path, char delim, std::vector<std::vector<float>>& dat) const;
   };
 
   class Timepix3TrigEvent2StdEventConverter: public eudaq::StdEventConverter{

--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -17,7 +17,7 @@ namespace eudaq {
     static size_t m_clearedHeader;
 
     // configuration parameters:
-    static bool first_time;     // How to avoid this with an Initialize() function?
+    static bool m_first_time;
     static bool applyCalibration;
     static std::string calibrateDetector;
     static std::string calibrationPath;

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -260,7 +260,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         event_end = (ftimestamp > event_end) ? ftimestamp : event_end;
 
         // push new pixel object with non-calibrated values of tot and toa
-        plane.PushPixel(col, row, fcharge, ftimestamp); // <-- or also ToT? Can EUDAQ2 handle charge? false to identify overloaded function
+        plane.PushPixel(col, row, fcharge, ftimestamp); // <-- or also ToT? Can EUDAQ2 handle charge?
       } else {
         // Set event start/stop:
         event_begin = (timestamp < event_begin) ? timestamp : event_begin;

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -121,7 +121,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
                 }
             }
         } else {
-            EUDAQ_INFO("No calibration file path or no DUT name given; data will be uncalibrated.");
+            EUDAQ_INFO("No calibration file path for ToT or ToA; data will be uncalibrated.");
             applyCalibration = false;
         }
     }

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -84,9 +84,8 @@ uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime_prev(0);
 size_t Timepix3RawEvent2StdEventConverter::m_clearedHeader(0);
 bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
 bool Timepix3RawEvent2StdEventConverter::applyCalibration(false);
-std::string Timepix3RawEvent2StdEventConverter::calibrateDetector("");
-std::string Timepix3RawEvent2StdEventConverter::calibrationPath("");
-std::string Timepix3RawEvent2StdEventConverter::threshold("");
+std::string Timepix3RawEvent2StdEventConverter::calibrationPathToT("");
+std::string Timepix3RawEvent2StdEventConverter::calibrationPathToA("");
 std::vector<std::vector<float>> Timepix3RawEvent2StdEventConverter::vtot;
 std::vector<std::vector<float>> Timepix3RawEvent2StdEventConverter::vtoa;
 
@@ -97,19 +96,17 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       delta_t0 = conf->Get("delta_t0", 1e6); // default: 1sec
       EUDAQ_INFO("Will detect 2nd T0 indirectly if timestamp jumps back by more than " + to_string(delta_t0) + "ns.");
       m_first_time = false;
-      if(conf->Has("calibrate_detector") && conf->Has("calibration_path") && conf->Has("threshold")) {
-          calibrateDetector = conf->Get("calibrate_detector","");
-          calibrationPath = conf->Get("calibration_path","");
-          threshold = conf->Get("threshold","");
-          applyCalibration = true;
-          EUDAQ_INFO("Applying calibration from " + calibrationPath + " for detector " + calibrateDetector);
 
-          // make paths to calibration files and read
-            std::string tmp;
-            tmp = calibrationPath + "/" + calibrateDetector + "/cal_thr_" + threshold + "_ik_10/" + calibrateDetector + "_cal_tot.txt";
-            loadCalibration(tmp, ' ', vtot);
-            tmp = calibrationPath + "/" + calibrateDetector + "/cal_thr_" + threshold + "_ik_10/" + calibrateDetector + "_cal_toa.txt";
-            loadCalibration(tmp, ' ', vtoa);
+      if(conf->Has("calibration_path_tot") && conf->Has("calibration_path_toa")) {
+          calibrationPathToT = conf->Get("calibration_path_tot","");
+          calibrationPathToA = conf->Get("calibration_path_toa","");
+          applyCalibration = true;
+          EUDAQ_INFO("Applying ToT calibration from " + calibrationPathToT);
+          EUDAQ_INFO("Applying ToA calibration from " + calibrationPathToA);
+
+          std::string tmp;
+          loadCalibration(calibrationPathToT, ' ', vtot);
+          loadCalibration(calibrationPathToA, ' ', vtoa);
 
             for(size_t row = 0; row < 256; row++) {
                 for(size_t col = 0; col < 256; col++) {

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -262,8 +262,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
          * using testpulses. Multiplying the voltage value with 20 [e-/mV] is a good approximation but means one is
          * over estimating the input capacitance to compensate the missing information of the offset. */
 
-        uint64_t t_shift = (toa_c / (fvolts - toa_t) + toa_d) * 1000; // convert to ps // was float
-        const uint64_t ftimestamp = timestamp - t_shift; // uint64_t - float?! // was float
+        uint64_t t_shift = (toa_c / (fvolts - toa_t) + toa_d) * 1000; // convert to ps
+        const uint64_t ftimestamp = timestamp - t_shift;
         EUDAQ_DEBUG("Time shift = " + to_string(t_shift) + "ps");
         EUDAQ_DEBUG("Timestamp calibrated = " + to_string(ftimestamp) + "ps");
 

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -82,8 +82,8 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
 uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime(0);
 uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime_prev(0);
 size_t Timepix3RawEvent2StdEventConverter::m_clearedHeader(0);
+bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
 bool Timepix3RawEvent2StdEventConverter::applyCalibration(false);
-bool Timepix3RawEvent2StdEventConverter::first_time(true);
 std::string Timepix3RawEvent2StdEventConverter::calibrateDetector("");
 std::string Timepix3RawEvent2StdEventConverter::calibrationPath("");
 std::string Timepix3RawEvent2StdEventConverter::threshold("");
@@ -93,7 +93,7 @@ std::vector<std::vector<float>> Timepix3RawEvent2StdEventConverter::vtoa;
 bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
 
   // Read from configuration:
-  if(first_time) {
+  if(m_first_time) {
       if(conf->Has("calibrate_detector") && conf->Has("calibration_path") && conf->Has("threshold")) {
           calibrateDetector = conf->Get("calibrate_detector","");
           calibrationPath = conf->Get("calibration_path","");
@@ -126,7 +126,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
             EUDAQ_INFO("No calibration file path or no DUT name given; data will be uncalibrated.");
             applyCalibration = false;
         }
-        first_time = false;
+        m_first_time = false;
     }
 
   bool data_found = false;

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -237,7 +237,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       // Apply calibration if applyCalibration is true
       // (copied over from Corryvreckan EventLoaderTimepix3)
       if(applyCalibration) {
-        // LOG(DEBUG) << "Applying calibration to DUT";
+        // EUDAQ_DEBUG()"Applying calibration to DUT"); // cannot change verbosity in Corryvreckan
         size_t scol = static_cast<size_t>(col);
         size_t srow = static_cast<size_t>(row);
         float a = vtot.at(256 * srow + scol).at(2);
@@ -263,8 +263,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
 
         uint64_t t_shift = (toa_c / (fvolts - toa_t) + toa_d) * 1000; // convert to ps
         const uint64_t ftimestamp = timestamp - t_shift;
-        EUDAQ_DEBUG("Time shift = " + to_string(t_shift) + "ps");
-        EUDAQ_DEBUG("Timestamp calibrated = " + to_string(ftimestamp) + "ps");
+        // EUDAQ_DEBUG("Time shift = " + to_string(t_shift) + "ps"); // cannot change verbosity in Corryvreckan
+        // EUDAQ_DEBUG("Timestamp calibrated = " + to_string(ftimestamp) + "ps"); // cannot change verbosity in Corryvreckan
 
         if(col >= 256 || row >= 256) {
             EUDAQ_WARN("Pixel address " + std::to_string(col) + ", " + std::to_string(row) + " is outside of pixel matrix.");

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -1,5 +1,5 @@
 #include "Timepix3Event2StdEventConverter.hh"
-#include <math.h> // for sqrt()
+#include <cmath> // for sqrt()
 
 using namespace eudaq;
 

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -196,3 +196,45 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
 
   return data_found;
 }
+
+void Timepix3RawEvent2StdEventConverter::loadCalibration(std::string path, char delim, std::vector<std::vector<float>>& dat) const {
+    // copied from Corryvreckan EventLoaderTimepix3
+    std::ifstream f;
+    f.open(path);
+    dat.clear();
+
+    // check if file is open
+    if(!f.is_open()) {
+        EUDAQ_WARN("Cannot open input file:\n\t" + path);
+        // throw InvalidValueError(config_, "calibration_path", "Parsing error in calibration file.");
+        return;
+    }
+
+    // read file line by line
+    int i = 0;
+    std::string line;
+    while(!f.eof()) {
+        std::getline(f, line);
+
+        // check if line is empty or a comment
+        // if not write to output vector
+        if(line.size() > 0 && isdigit(line.at(0))) {
+            std::stringstream ss(line);
+            std::string word;
+            std::vector<float> row;
+            while(std::getline(ss, word, delim)) {
+                i += 1;
+                row.push_back(stof(word));
+            }
+            dat.push_back(row);
+        }
+    }
+
+    // warn if too few entries
+    if(dat.size() != 256 * 256) {
+        EUDAQ_WARN("Something went wrong. Found only " + to_string(i) + " entries. Not enough for TPX3.\n\t");
+        // throw InvalidValueError(config_, "calibration_path", "Parsing error in calibration file.");
+    }
+
+    f.close();
+}

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -83,7 +83,6 @@ uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime(0);
 uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime_prev(0);
 bool Timepix3RawEvent2StdEventConverter::m_clearedHeader(false);
 bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
-bool Timepix3RawEvent2StdEventConverter::applyCalibration(false);
 std::vector<std::vector<float>> Timepix3RawEvent2StdEventConverter::vtot;
 std::vector<std::vector<float>> Timepix3RawEvent2StdEventConverter::vtoa;
 
@@ -98,7 +97,6 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       if(conf->Has("calibration_path_tot") && conf->Has("calibration_path_toa")) {
           std::string calibrationPathToT = conf->Get("calibration_path_tot","");
           std::string calibrationPathToA = conf->Get("calibration_path_toa","");
-          applyCalibration = true;
           EUDAQ_INFO("Applying ToT calibration from " + calibrationPathToT);
           EUDAQ_INFO("Applying ToA calibration from " + calibrationPathToA);
 
@@ -122,7 +120,6 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
             }
         } else {
             EUDAQ_INFO("No calibration file path for ToT or ToA; data will be uncalibrated.");
-            applyCalibration = false;
         }
     }
 
@@ -230,9 +227,9 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       // Convert final timestamp into picoseconds
       const uint64_t timestamp = time * 1000 / 4096 * 25;
 
-      // Apply calibration if applyCalibration is true
+      // Apply calibration if both vtot and vtoa are not empty
       // (copied over from Corryvreckan EventLoaderTimepix3)
-      if(applyCalibration) {
+      if(!vtot.empty() && !vtoa.empty()) {
         // EUDAQ_DEBUG()"Applying calibration to DUT"); // cannot change verbosity in Corryvreckan
         size_t scol = static_cast<size_t>(col);
         size_t srow = static_cast<size_t>(row);

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -307,8 +307,7 @@ void Timepix3RawEvent2StdEventConverter::loadCalibration(std::string path, char 
 
     // check if file is open
     if(!f.is_open()) {
-        EUDAQ_WARN("Cannot open input file:\n\t" + path);
-        // throw InvalidValueError(config_, "calibration_path", "Parsing error in calibration file.");
+        throw DataInvalid("Cannot open calibration file:\n\t" + path);
         return;
     }
 
@@ -334,8 +333,7 @@ void Timepix3RawEvent2StdEventConverter::loadCalibration(std::string path, char 
 
     // warn if too few entries
     if(dat.size() != 256 * 256) {
-        EUDAQ_WARN("Something went wrong. Found only " + to_string(i) + " entries. Not enough for TPX3.\n\t");
-        // throw InvalidValueError(config_, "calibration_path", "Parsing error in calibration file.");
+        throw DataInvalid("Something went wrong. Found only " + to_string(i) + " entries. Not enough for TPX3.\n\t");
     }
 
     f.close();

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -84,8 +84,6 @@ uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime_prev(0);
 size_t Timepix3RawEvent2StdEventConverter::m_clearedHeader(0);
 bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
 bool Timepix3RawEvent2StdEventConverter::applyCalibration(false);
-std::string Timepix3RawEvent2StdEventConverter::calibrationPathToT("");
-std::string Timepix3RawEvent2StdEventConverter::calibrationPathToA("");
 std::vector<std::vector<float>> Timepix3RawEvent2StdEventConverter::vtot;
 std::vector<std::vector<float>> Timepix3RawEvent2StdEventConverter::vtoa;
 
@@ -98,8 +96,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       m_first_time = false;
 
       if(conf->Has("calibration_path_tot") && conf->Has("calibration_path_toa")) {
-          calibrationPathToT = conf->Get("calibration_path_tot","");
-          calibrationPathToA = conf->Get("calibration_path_toa","");
+          std::string calibrationPathToT = conf->Get("calibration_path_tot","");
+          std::string calibrationPathToA = conf->Get("calibration_path_toa","");
           applyCalibration = true;
           EUDAQ_INFO("Applying ToT calibration from " + calibrationPathToT);
           EUDAQ_INFO("Applying ToA calibration from " + calibrationPathToA);

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -1,4 +1,5 @@
 #include "Timepix3Event2StdEventConverter.hh"
+#include <math.h> // for sqrt()
 
 using namespace eudaq;
 
@@ -71,7 +72,7 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
   // Set timestamps for StdEvent in nanoseconds (timestamps are picoseconds):
   d2->SetTimeBegin(triggerTime);
   d2->SetTimeEnd(triggerTime);
-  
+
   // Identify the detetor type
   d2->SetDetectorType("SpidrTrigger");
 

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -274,8 +274,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         event_begin = (ftimestamp < event_begin) ? ftimestamp : event_begin;
         event_end = (ftimestamp > event_end) ? ftimestamp : event_end;
 
-        // push new pixel object with non-calibrated values of tot and toa
-        plane.PushPixel(col, row, fcharge, ftimestamp); // <-- or also ToT? Can EUDAQ2 handle charge?
+        // push new pixel object with calibrated values of tot and toa
+        plane.PushPixel(col, row, fcharge, ftimestamp);
       } else {
         // Set event start/stop:
         event_begin = (timestamp < event_begin) ? timestamp : event_begin;


### PR DESCRIPTION
This MR copies over chunks of code from the Corryvreckan EventLoaderTimepix3 (see [here](https://gitlab.cern.ch/corryvreckan/corryvreckan/-/tree/master/src/modules/EventLoaderTimepix3)) to read in a lab-based calibration file:

* ToT -> charge
* ToA -> timewalk correction