### PR TITLE
Fix T0 Detection for CLICpix2

### DIFF
--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -129,17 +129,17 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
     return false;
   }
 
-  // Check for a sane shutter:
-  if(shutter_open > shutter_close) {
-    EUDAQ_WARN("Frame with shutter close before shutter open: " + std::to_string(ev->GetEventNumber()));
-    return false;
-  }
-
   // Check if there was a T0:
   if(last_shutter_open_ > shutter_open) {
       t0_seen_++;
   }
   last_shutter_open_ = shutter_open;
+
+  // Check for a sane shutter:
+  if(shutter_open > shutter_close) {
+    EUDAQ_WARN("Frame with shutter close before shutter open: " + std::to_string(ev->GetEventNumber()));
+    return false;
+  }
 
   // FIXME - hardcoded configuration:
   bool drop_before_t0 = true;


### PR DESCRIPTION
If T0 is detected between shutter open and shutter close this was not detected previously.
It is not a problem when T0 is received in any event later than the first one.

In the new mode in which the trigger closes the shutter we observed that the T0 is received within the first event. We just swapped the logic blocks and the issue is solved.