### PR TITLE
WIP: Throw exception on 2nd T0

### DIFF
--- a/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
+++ b/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
@@ -65,7 +65,7 @@ private:
     static uint64_t fpga_ts3_;
     static bool new_ts1_;
     static bool new_ts2_;
-    static bool timestamps_cleared_;
+    static size_t t0_seen_;
   };
 
 } // namespace eudaq

--- a/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
+++ b/user/caribou/module/include/CaribouEvent2StdEventConverter.hh
@@ -34,7 +34,7 @@ namespace eudaq {
     bool Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const override;
     static const uint32_t m_id_factory = eudaq::cstr2hash("CaribouCLICTDEvent");
   private:
-    static bool t0_seen_;
+    static size_t t0_seen_;
     static bool t0_is_high_;
     static uint64_t last_shutter_open_;
   };

--- a/user/caribou/module/src/ATLASPixEventConverter.cc
+++ b/user/caribou/module/src/ATLASPixEventConverter.cc
@@ -23,7 +23,7 @@ uint64_t ATLASPixEvent2StdEventConverter::fpga_ts2_(0);
 uint64_t ATLASPixEvent2StdEventConverter::fpga_ts3_(0);
 bool ATLASPixEvent2StdEventConverter::new_ts1_(false);
 bool ATLASPixEvent2StdEventConverter::new_ts2_(false);
-bool ATLASPixEvent2StdEventConverter::timestamps_cleared_(false);
+size_t ATLASPixEvent2StdEventConverter::t0_seen_(0);
 
 bool ATLASPixEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
   auto ev = std::dynamic_pointer_cast<const eudaq::RawEvent>(d1);
@@ -45,9 +45,12 @@ bool ATLASPixEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   // Check if current word is a pixel data:
   if(datain & 0x80000000) {
     // Do not return and decode pixel data before T0 arrived
-    if(!timestamps_cleared_) {
+    if(t0_seen_ == 0) {
       return false;
-    }
+  } else if (t0_seen_ > 1) {
+      // throw exception and interrupt analysis:
+      throw DataInvalid("Detected 2nd T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
+  }
     // Structure: {1'b1, column_addr[5:0], row_addr[8:0], rise_timestamp[9:0], fall_timestamp[5:0]}
     // Extract pixel data
     long ts2 = gray_decode((datain)&0x003F);
@@ -164,7 +167,7 @@ bool ATLASPixEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
       fpga_ts1_ = 0;
       fpga_ts2_ = 0;
       fpga_ts3_ = 0;
-      timestamps_cleared_ = true;
+      t0_seen_++;
     } else if(message_type == 0b00000000) {
 
       // Empty data - should not happen

--- a/user/caribou/module/src/CLICTDEventConverter.cc
+++ b/user/caribou/module/src/CLICTDEventConverter.cc
@@ -12,7 +12,7 @@ namespace{
 }
 
 bool CLICTDEvent2StdEventConverter::t0_is_high_(false);
-bool CLICTDEvent2StdEventConverter::t0_seen_(false);
+size_t CLICTDEvent2StdEventConverter::t0_seen_(0);
 uint64_t CLICTDEvent2StdEventConverter::last_shutter_open_(0);
 bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
   auto ev = std::dynamic_pointer_cast<const eudaq::RawEvent>(d1);
@@ -134,11 +134,17 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
       // Check for T0 signal going from high to low
       if(!(signals & 0x1) && t0_is_high_) {
-        t0_seen_ = true;
+        t0_seen_++;
         t0_is_high_ = false;
-        EUDAQ_INFO("Detected T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
-        // Discard this event:
-        return false;
+
+        if(t0_seen_ == 1) {
+            EUDAQ_INFO("Detected 1st T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
+            // Discard this event:
+            return false;
+        } else {
+            // throw exception and interrupt analysis:
+            throw DataInvalid("Detected 2nd T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
+        }
       }
     } else {
       // New format:
@@ -157,10 +163,15 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
 
       // Check for T0 signal going from high to low
       if((triggers & 0x1) && !(signals & 0x1)) {
-        t0_seen_ = true;
-        EUDAQ_INFO("Detected T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
-        // Discard this event:
-        return false;
+        t0_seen_++;
+        if(t0_seen_ == 1) {
+            EUDAQ_INFO("Detected 1st T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
+            // Discard this event:
+            return false;
+        } else {
+            // throw exception and interrupt analysis:
+            throw DataInvalid("Detected 2nd T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
+        }
       }
     }
   }
@@ -171,29 +182,39 @@ bool CLICTDEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
     return false;
   }
 
-  // Check for a sane shutter:
+  // Check for a sane shutter, else T0 during shutter open:
   if(shutter_open > shutter_close) {
     EUDAQ_WARN("Frame with shutter close before shutter open: " + std::to_string(ev->GetEventNumber()));
-    return false;
-  }
-
-  // Check if there was a T0:
-  if(!t0_seen_) {
-    // Last shutter open had higher timestamp than this one:
-    t0_seen_ = (last_shutter_open_ > shutter_open);
-    // Log when we have it detector:
-    if(t0_seen_) {
-      EUDAQ_INFO("Detected T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts jump)");
-      // Discard this event:
-      return false;
+    t0_seen_++;
+    if(t0_seen_==1) {
+        return false;
+    } else {
+        // throw exception and interrupt analysis:
+        throw DataInvalid("Detected 2nd T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
     }
   }
+
+  // Check if there was a T0 between shutters:
+  // Last shutter open had higher timestamp than this one:
+  if (last_shutter_open_ > shutter_open) {
+      t0_seen_++;
+      // Log when we have it detector:
+      if(t0_seen_==1) {
+          EUDAQ_INFO("Detected T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts jump)");
+          // Discard this event:
+          return false;
+      } else if (t0_seen_ > 1) {
+          // throw exception and interrupt analysis:
+          throw DataInvalid("Detected 2nd T0 signal in event: " + std::to_string(ev->GetEventNumber()) + " (ts signal)");
+      }
+  }
+
   last_shutter_open_ = shutter_open;
 
   // FIXME - hardcoded configuration:
   bool drop_before_t0 = true;
   // No T0 signal seen yet, dropping frame:
-  if(drop_before_t0 && !t0_seen_) {
+  if(drop_before_t0 && t0_seen_==0) {
     return false;
   }
 

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -147,11 +147,9 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   if(drop_before_t0 && (t0_seen_==0)) {
     return false;
   }
-  // drop everything after second t0 has been seen:
+  // throw exception when T0 occurs more than once:
   if(t0_seen_>1) {
-      std::string message = "Detected T0 " + std::to_string(t0_seen_) + " times.";
-      EUDAQ_WARN(message);
-      throw DataInvalid(message);
+      throw DataInvalid("Detected T0 " + std::to_string(t0_seen_) + " times.");
   }
 
   // Decode the data:

--- a/user/caribou/module/src/CLICpix2EventConverter.cc
+++ b/user/caribou/module/src/CLICpix2EventConverter.cc
@@ -149,8 +149,9 @@ bool CLICpix2Event2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Stan
   }
   // drop everything after second t0 has been seen:
   if(t0_seen_>1) {
-      EUDAQ_WARN("Detected T0 " + std::to_string(t0_seen_) + " times.");
-      return false;
+      std::string message = "Detected T0 " + std::to_string(t0_seen_) + " times.";
+      EUDAQ_WARN(message);
+      throw DataInvalid(message);
   }
 
   // Decode the data:


### PR DESCRIPTION
...as the title says. Liked to https://gitlab.cern.ch/corryvreckan/corryvreckan/-/merge_requests/346

**CLICpix2:**
* already checked for 2nd T0
* would return false after detection of 2nd T0 all the way until reaching end-of-file
* now throw exception
* tested with run 1137 from July 2019

**CLICTD:**
* also checked for multiple T0s, but would only print a warning to the terminal, nothing else
* now throw exception
* tested with run 5151 from July 2020

**ATLASpix:**
* was able to detect 2nd T0, but would only reset all timestamps and keep going
* now throw exception
* plan to test this with new data in August 2020

**Timepix3:**
* no good possibility to check for 2nd T0, only indirectly by comparing timestamps to previous timestamps
* would only receive 2nd T0 and reset all timestamps but keep going
* WIP: implementing better solution
* to be tested...