### PR TITLE
Throw exception on 2nd T0 -- follow up

### DIFF
--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -13,7 +13,8 @@ namespace eudaq {
     static const uint32_t m_id_factory = eudaq::cstr2hash("Timepix3RawEvent");
   private:
     static uint64_t m_syncTime;
-    static bool m_clearedHeader;
+    static uint64_t m_syncTime_prev;
+    static size_t m_clearedHeader;
   };
 
   class Timepix3TrigEvent2StdEventConverter: public eudaq::StdEventConverter{

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -131,7 +131,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         m_syncTime = (m_syncTime & 0x00000FFFFFFFFFFF) + ((pixdata & 0x00000000FFFF0000) << 28);
 
         if(m_clearedHeader==0 && (m_syncTime / 4096 / 40) < 6000000) { // < 6sec
-          EUDAQ_INFO("Detected T0 signal in event: " + std::to_string(ev->GetEventNumber()));
+          EUDAQ_INFO("Detected T0 signal. Header cleared.");
           m_clearedHeader++;
 
         // From SPS data we know that even though pixel timestamps are not perfectly chronological, they are not more
@@ -153,7 +153,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
     if(m_clearedHeader == 0) {
         continue;
     } else if(m_clearedHeader > 1) {
-        throw DataInvalid("Detected 2nd T0 signal in event: " + std::to_string(ev->GetEventNumber()));
+        throw DataInvalid("Detected second T0 signal.");
     }
 
     // Header 0xA and 0xB indicate pixel data

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -130,21 +130,16 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         // The data is shifted 16 bits to the right, then 44 to the left in order to match the timestamp format (net 28 left)
         m_syncTime = (m_syncTime & 0x00000FFFFFFFFFFF) + ((pixdata & 0x00000000FFFF0000) << 28);
 
-        std::cout << "syncTime / syncTime_prev = " << m_syncTime / 4096 / 40 / 1e6 << "s, " << m_syncTime_prev / 4096 / 40 / 1e6 << "s"<< std::endl;
-
-        // if(((m_syncTime / 4096 / 40) < 6000000) && ((m_syncTime_prev / 4096 / 40) > 6000000)) {
-        if(m_clearedHeader==0 && (m_syncTime / 4096 / 40) < 6000000) {
-          EUDAQ_WARN("Detected T0 signal in event: " + std::to_string(ev->GetEventNumber()));
+        if(m_clearedHeader==0 && (m_syncTime / 4096 / 40) < 6000000) { // < 6sec
+          EUDAQ_INFO("Detected T0 signal in event: " + std::to_string(ev->GetEventNumber()));
           m_clearedHeader++;
-        }
-        // If the current timestamp is more than 20us earlier than the previous timestamp, assume a 2nd T0 has occured.
-        // From SPS data we know that even though pixel timestamps are not perfectly chronological, they are not more
-        // than "inverted by -20us". Take 100us with some safety margin.
-        // This implies we cannot detect a 2nd T0 within the first 100us after the initial T0. But did this ever happen?
 
-        // One more comment: this timestamp is the "heartbeat" and seems to be incremented by ~1sec, it's not the pixel timestamp directly.
-        else if (m_syncTime < m_syncTime_prev - 50 * 4096 * 40) {
-          std::cout << "m_syncTime - m_syncTime_prev: " << (m_syncTime - m_syncTime_prev) / 4096 / 40 << std::endl;
+        // From SPS data we know that even though pixel timestamps are not perfectly chronological, they are not more
+        // than "mixed up by -20us". At DESY, this is hardly (ever?) the case due to the lower occupancies.
+        // Hence, if the current timestamp is more than 20us earlier than the previous timestamp, we can assume that
+        // a 2nd T0 has occured. Take 100us with some safety margin.
+        // This implies we cannot detect a 2nd T0 within the first 100us after the initial T0. But did this ever happen?
+        } else if (m_syncTime < m_syncTime_prev - (50 * 4096 * 40)) {
           m_clearedHeader++;
         }
         m_syncTime_prev = m_syncTime;
@@ -153,8 +148,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
 
     // Sometimes there is still data left in the buffers at the start of a run. For that reason we keep skipping data until
     // this "header" data has been cleared, when the heart beat signal starts from a low number (~few seconds max).
-    // To detect a possible second T0, we have no better gauge than the same criterion.
-    // However, that's probably okay since this usually happens only after much more than 10 sec or so.
+    // To detect a possible second T0, we have no better gauge than the same criterion:
+    // Comparing the timestamp to the previous timestamp (see above).
     if(m_clearedHeader == 0) {
         continue;
     } else if(m_clearedHeader > 1) {


### PR DESCRIPTION
This is a follow up on #18 and implements the T0 detection for the TPX3:

**Timepix3:**
- no direct possibility to detect 2nd T0, only indirectly by comparing timestamps to previous timestamps
- previously would only receive 2nd T0 and reset all timestamps but keep going
- now throw exception
- tested with the followings runs from July 2020: 5148, 5151, 5152
