### PR TITLE
Timepix3 2nd T0 parameter + docu

### DIFF
--- a/user/timepix3/README.md
+++ b/user/timepix3/README.md
@@ -27,7 +27,7 @@ Since the SPIDR device libraries are not thread-safe, all access to SPIDR librar
 
 The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
-* `delta_t_t0`: Integer in microseconds as the criterion for the indirect T0 detection. If the Timepix3 timestamps jump back by more than this value, a 2nd T0 is assumed to have been recorded. The value needs to be passed as an integer without units, but a syntax such as `1e3` is supported. Defaults to `1e6` (corresponding to 1s).
+* `delta_t0`: Integer in microseconds as the criterion for the indirect T0 detection. If the Timepix3 timestamps jump back by more than this value, a 2nd T0 is assumed to have been recorded. The value needs to be passed as an integer without units, but a syntax such as `1e3` is supported. Defaults to `1e6` (corresponding to 1s).
 
 ### Timepix3TrigEvent2StdEventConverter
 

--- a/user/timepix3/README.md
+++ b/user/timepix3/README.md
@@ -1,9 +1,10 @@
 # Timepix3 Module for EUDAQ2
 
-This module allows to integrate Timepix3 sensors running with the SPIDR readout system into the EUDAQ2 eco system.
+This module allows to integrate a Timepix3 sensor running with the SPIDR readout system into the EUDAQ2 eco system.
+In addition, the fast ADC input on the SPIDR board can be used as a SPIDRTrigger auxiliary device.
 
 Currently, this producer is in early development stage and has only been tested in the AIDA mode, i.e. receiving a global clock and a T0 signal at beginning of the run.
-The producer interfaces the SPIDR device manager to add devices and to control them. The following actions are performed in the different FSM stages:
+The producer interfaces the SPIDR DAQ software via a `SpidrController` to control the Timepix3. The following actions are performed in the different FSM stages:
 
 * **Initialisation**: The device to be instantiated is taken from the name of the producer (added with `-t <name>` on the command line). This means, the following command
 
@@ -11,9 +12,9 @@ The producer interfaces the SPIDR device manager to add devices and to control t
     $ euCliProducer -n Timepix3Producer -t Timepix3 -r <tcp>
     ```
 
-    will ask SPIDR to instantiate a Timepix3 device. Device names are case sensitive and have to be available in the linked SPIDR installation.
+    will ask the `SpidrController` to establish a network connection, retrieve software and firmware versions, and determines the number of connected devices.
 
-* **Configuration**: During configuration, the device is powered using SPIDR's `powerOn()` command. After this, the producer waits for one second in order to allow the AIDA TLU to fully configure and make the clock available on the DUT outputs. Then, the `configure()` command of the SPIDR device interface is called.
+* **Configuration**: Before configuration of the device, the producer waits for one second in order to allow the AIDA TLU to fully configure and make the clock available on the DUT outputs. Then, the device is configured.
 
 * **DAQ Start / Stop**: During DAQ start and stop, the corresponding SPIDR device functions are called.
 
@@ -26,8 +27,8 @@ Since the SPIDR device libraries are not thread-safe, all access to SPIDR librar
 
 The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
-* `delta_t_t0`: Integer in nanoseconds to determine the criterion for the indirect T0 detection. If the Timepix3 timestamps jump back by more than this value, a 2nd T0 is assumed to have been recorded. The value needs to be passed without units, but a syntax such as `1e3` is supported. Defaults to `1e6`.
+* `delta_t_t0`: Integer in microseconds as the criterion for the indirect T0 detection. If the Timepix3 timestamps jump back by more than this value, a 2nd T0 is assumed to have been recorded. The value needs to be passed as an integer without units, but a syntax such as `1e3` is supported. Defaults to `1e6` (corresponding to 1s).
 
 ### Timepix3TrigEvent2StdEventConverter
 
-The following parameters can be passed...
+No parameters.

--- a/user/timepix3/README.md
+++ b/user/timepix3/README.md
@@ -1,3 +1,33 @@
-# Timepix3
+# Timepix3 Module for EUDAQ2
 
-Integration
+This module allows to integrate Timepix3 sensors running with the SPIDR readout system into the EUDAQ2 eco system.
+
+Currently, this producer is in early development stage and has only been tested in the AIDA mode, i.e. receiving a global clock and a T0 signal at beginning of the run.
+The producer interfaces the SPIDR device manager to add devices and to control them. The following actions are performed in the different FSM stages:
+
+* **Initialisation**: The device to be instantiated is taken from the name of the producer (added with `-t <name>` on the command line). This means, the following command
+
+    ```
+    $ euCliProducer -n Timepix3Producer -t Timepix3 -r <tcp>
+    ```
+
+    will ask SPIDR to instantiate a Timepix3 device. Device names are case sensitive and have to be available in the linked SPIDR installation.
+
+* **Configuration**: During configuration, the device is powered using SPIDR's `powerOn()` command. After this, the producer waits for one second in order to allow the AIDA TLU to fully configure and make the clock available on the DUT outputs. Then, the `configure()` command of the SPIDR device interface is called.
+
+* **DAQ Start / Stop**: During DAQ start and stop, the corresponding SPIDR device functions are called.
+
+Since the SPIDR device libraries are not thread-safe, all access to SPIDR libraries is guarded using C++11 `std::lock_guard` with a central class-member mutex to avoid concurrent device access.
+
+
+## Data Converters to StandardEvent
+
+### Timepix3RawEvent2StdEventConverter
+
+The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
+
+* `delta_t_t0`: Integer in nanoseconds to determine the criterion for the indirect T0 detection. If the Timepix3 timestamps jump back by more than this value, a 2nd T0 is assumed to have been recorded. The value needs to be passed without units, but a syntax such as `1e3` is supported. Defaults to `1e6`.
+
+### Timepix3TrigEvent2StdEventConverter
+
+The following parameters can be passed...

--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -15,6 +15,7 @@ namespace eudaq {
     static uint64_t m_syncTime;
     static uint64_t m_syncTime_prev;
     static size_t m_clearedHeader;
+    static bool m_first_time;     // How to avoid this with an Initialize() function?
   };
 
   class Timepix3TrigEvent2StdEventConverter: public eudaq::StdEventConverter{

--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -15,7 +15,7 @@ namespace eudaq {
     static uint64_t m_syncTime;
     static uint64_t m_syncTime_prev;
     static size_t m_clearedHeader;
-    static bool m_first_time;     // How to avoid this with an Initialize() function?
+    static bool m_first_time;
   };
 
   class Timepix3TrigEvent2StdEventConverter: public eudaq::StdEventConverter{

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -85,9 +85,9 @@ bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
 bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
 
   // Time difference as criterion for indirect T0 detection (time to previous hit) in MICRO-seconds:
-  uint64_t delta_t_t0 = conf->Get("delta_t_t0", 1e6); // default: 1sec
+  uint64_t delta_t0 = conf->Get("delta_t0", 1e6); // default: 1sec
   if(m_first_time){
-      EUDAQ_INFO("Will detect 2nd T0 indirectly if timestamp jumps back by more than " + to_string(delta_t_t0) + "ns.");
+      EUDAQ_INFO("Will detect 2nd T0 indirectly if timestamp jumps back by more than " + to_string(delta_t0) + "ns.");
       m_first_time = false;
   }
 
@@ -146,8 +146,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         // than "mixed up by -20us". At DESY, this is hardly (ever?) the case due to the lower occupancies.
         // Hence, if the current timestamp is more than 20us earlier than the previous timestamp, we can assume that
         // a 2nd T0 has occured.
-        // This implies we cannot detect a 2nd T0 within the first "delta_t_t0" microseconds after the initial T0.
-      } else if (m_syncTime < m_syncTime_prev - (delta_t_t0 * 4096 * 40)) {
+        // This implies we cannot detect a 2nd T0 within the first "delta_t0" microseconds after the initial T0.
+      } else if (m_syncTime < m_syncTime_prev - (delta_t0 * 4096 * 40)) {
           m_clearedHeader++;
         }
         m_syncTime_prev = m_syncTime;

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -81,7 +81,15 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
 uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime(0);
 uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime_prev(0);
 size_t Timepix3RawEvent2StdEventConverter::m_clearedHeader(0);
+bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
 bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
+
+  // Time difference as criterion for indirect T0 detection (time to previous hit) in nanoseconds:
+  uint64_t delta_t_t0 = conf->Get("delta_t_t0", 1e6);
+  if(m_first_time){
+      EUDAQ_INFO("Will detect 2nd T0 indirectly if timestamp jumps back by more than " + to_string(delta_t_t0) + "ns.");
+      m_first_time = false;
+  }
 
   bool data_found = false;
 
@@ -137,9 +145,9 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         // From SPS data we know that even though pixel timestamps are not perfectly chronological, they are not more
         // than "mixed up by -20us". At DESY, this is hardly (ever?) the case due to the lower occupancies.
         // Hence, if the current timestamp is more than 20us earlier than the previous timestamp, we can assume that
-        // a 2nd T0 has occured. Take 500us with some safety margin.
-        // This implies we cannot detect a 2nd T0 within the first 500us after the initial T0. But did this ever happen?
-      } else if (m_syncTime < m_syncTime_prev - (500 * 4096 * 40)) {
+        // a 2nd T0 has occured.
+        // This implies we cannot detect a 2nd T0 within the first delta_t_t0 after the initial T0.
+      } else if (m_syncTime < m_syncTime_prev - (delta_t_t0 * 4096 * 40)) { // default: 1 sec
           m_clearedHeader++;
         }
         m_syncTime_prev = m_syncTime;

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -84,8 +84,8 @@ size_t Timepix3RawEvent2StdEventConverter::m_clearedHeader(0);
 bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
 bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
 
-  // Time difference as criterion for indirect T0 detection (time to previous hit) in nanoseconds:
-  uint64_t delta_t_t0 = conf->Get("delta_t_t0", 1e6);
+  // Time difference as criterion for indirect T0 detection (time to previous hit) in MICRO-seconds:
+  uint64_t delta_t_t0 = conf->Get("delta_t_t0", 1e6); // default: 1sec
   if(m_first_time){
       EUDAQ_INFO("Will detect 2nd T0 indirectly if timestamp jumps back by more than " + to_string(delta_t_t0) + "ns.");
       m_first_time = false;
@@ -146,8 +146,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         // than "mixed up by -20us". At DESY, this is hardly (ever?) the case due to the lower occupancies.
         // Hence, if the current timestamp is more than 20us earlier than the previous timestamp, we can assume that
         // a 2nd T0 has occured.
-        // This implies we cannot detect a 2nd T0 within the first delta_t_t0 after the initial T0.
-      } else if (m_syncTime < m_syncTime_prev - (delta_t_t0 * 4096 * 40)) { // default: 1 sec
+        // This implies we cannot detect a 2nd T0 within the first "delta_t_t0" microseconds after the initial T0.
+      } else if (m_syncTime < m_syncTime_prev - (delta_t_t0 * 4096 * 40)) {
           m_clearedHeader++;
         }
         m_syncTime_prev = m_syncTime;


### PR DESCRIPTION
This MR aims to introduce a parameter, which can be passed to the converter from Corry for the criterion to detect a 2nd T0 by observing how the timestamp jumps back.

Doing so, I realized that there was no real documentation, so that's also included in this MR (WIP)