### PR TITLE
Follow-up on #16 and #24 -- missing brackets

### DIFF
--- a/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
+++ b/user/timepix3/module/include/Timepix3Event2StdEventConverter.hh
@@ -14,7 +14,7 @@ namespace eudaq {
   private:
     static uint64_t m_syncTime;
     static uint64_t m_syncTime_prev;
-    static size_t m_clearedHeader;
+    static bool m_clearedHeader;
     static bool m_first_time;
   };
 

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -80,7 +80,7 @@ bool Timepix3TrigEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::
 
 uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime(0);
 uint64_t Timepix3RawEvent2StdEventConverter::m_syncTime_prev(0);
-size_t Timepix3RawEvent2StdEventConverter::m_clearedHeader(0);
+bool Timepix3RawEvent2StdEventConverter::m_clearedHeader(false);
 bool Timepix3RawEvent2StdEventConverter::m_first_time(true);
 bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::StandardEventSP d2, eudaq::ConfigurationSPC conf) const{
 
@@ -137,17 +137,17 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         // The data is shifted 16 bits to the right, then 44 to the left in order to match the timestamp format (net 28 left)
         m_syncTime = (m_syncTime & 0x00000FFFFFFFFFFF) + ((pixdata & 0x00000000FFFF0000) << 28);
 
-        if(m_clearedHeader==0 && (m_syncTime / 4096 / 40) < 6000000) { // < 6sec
+        if(!m_clearedHeader && (m_syncTime / 4096 / 40) < 6000000) { // < 6sec
           EUDAQ_INFO("Timepix3: Detected T0 signal. Header cleared.");
-          m_clearedHeader++;
+          m_clearedHeader = true;
 
         // From SPS data we know that even though pixel timestamps are not perfectly chronological, they are not more
         // than "mixed up by -20us". At DESY, this is hardly (ever?) the case due to the lower occupancies.
         // Hence, if the current timestamp is more than 20us earlier than the previous timestamp, we can assume that
-        // a 2nd T0 has occured.
+        // a 2nd T0 has occured. With some safety margin, set delta_t0 = 1e6 (1s, default).
         // This implies we cannot detect a 2nd T0 within the first "delta_t0" microseconds after the initial T0.
-    } else if (m_syncTime < m_syncTime_prev - (0xFFFFFFFFFFFFFFFF & (delta_t0 * 4096 * 40))) { // mask to avoid wrap-around of uint64_t
-          m_clearedHeader++;
+        } else if ((m_syncTime + delta_t0 * 4096 * 40) < m_syncTime_prev) { // delta_t0 on left side to avoid neg. difference between uint64_t
+          throw DataInvalid("Timepix3: Detected second T0 signal. Time jumps back by " + to_string((m_syncTime_prev - m_syncTime) / 4096 / 40) + "us.");
         }
         m_syncTime_prev = m_syncTime;
       }
@@ -157,10 +157,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
     // this "header" data has been cleared, when the heart beat signal starts from a low number (~few seconds max).
     // To detect a possible second T0, we have no better gauge than the same criterion:
     // Comparing the timestamp to the previous timestamp (see above).
-    if(m_clearedHeader == 0) {
+    if(!m_clearedHeader) {
         continue;
-    } else if(m_clearedHeader > 1) {
-        throw DataInvalid("Timepix3: Detected second T0 signal.");
     }
 
     // Header 0xA and 0xB indicate pixel data

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -146,7 +146,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
         // Hence, if the current timestamp is more than 20us earlier than the previous timestamp, we can assume that
         // a 2nd T0 has occured.
         // This implies we cannot detect a 2nd T0 within the first "delta_t0" microseconds after the initial T0.
-    } else if (m_syncTime < m_syncTime_prev - 0xFFFFFFFFFFFFFFFF & (delta_t0 * 4096 * 40)) { // mask to avoid wrap-around of uint64_t
+    } else if (m_syncTime < m_syncTime_prev - (0xFFFFFFFFFFFFFFFF & (delta_t0 * 4096 * 40))) { // mask to avoid wrap-around of uint64_t
           m_clearedHeader++;
         }
         m_syncTime_prev = m_syncTime;


### PR DESCRIPTION
The masking introduced in #24 doesn't work correctly without brackets, i.e. the condition was never met and a 2nd T0 was not recognized.

Now it's for sure tested with a couple of runs and I do get the T0 exception when expected.
Sorry for the mess...