### PR TITLE
Timepix3Event2StdEventConverter: throw exception if calibration_path makes no sense

### DIFF
--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -99,10 +99,10 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
           std::string calibrationPathToA = conf->Get("calibration_path_toa","");
 
           if(calibrationPathToT.find("toa") != std::string::npos) {
-              throw DataInvalid("Timepix3: Parameter calibration_path_toa contains substring \"toa\", please update your configuration file!");
+              throw DataInvalid("Timepix3: Parameter calibration_path_tot contains substring \"toa\", please update your configuration file!");
           }
           if(calibrationPathToA.find("tot") != std::string::npos) {
-              throw DataInvalid("Timepix3: Parameter calibration_path_tot contains substring \"tot\", please update your configuration file!");
+              throw DataInvalid("Timepix3: Parameter calibration_path_toa contains substring \"tot\", please update your configuration file!");
           }
 
           EUDAQ_INFO("Applying ToT calibration from " + calibrationPathToT);

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -99,10 +99,10 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
           std::string calibrationPathToA = conf->Get("calibration_path_toa","");
 
           if(calibrationPathToT.find("toa") != std::string::npos) {
-              throw DataInvalid("Timepix3: Parameter calibration_path_toa contains substring \"tot\", please update your configuration file!");
+              throw DataInvalid("Timepix3: Parameter calibration_path_toa contains substring \"toa\", please update your configuration file!");
           }
-          if(calibrationPathToT.find("tot") != std::string::npos) {
-              throw DataInvalid("Timepix3: Parameter calibration_path_tot contains substring \"toa\", please update your configuration file!");
+          if(calibrationPathToA.find("tot") != std::string::npos) {
+              throw DataInvalid("Timepix3: Parameter calibration_path_tot contains substring \"tot\", please update your configuration file!");
           }
 
           EUDAQ_INFO("Applying ToT calibration from " + calibrationPathToT);

--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -97,6 +97,14 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       if(conf->Has("calibration_path_tot") && conf->Has("calibration_path_toa")) {
           std::string calibrationPathToT = conf->Get("calibration_path_tot","");
           std::string calibrationPathToA = conf->Get("calibration_path_toa","");
+
+          if(calibrationPathToT.find("toa") != std::string::npos) {
+              throw DataInvalid("Timepix3: Parameter calibration_path_toa contains substring \"tot\", please update your configuration file!");
+          }
+          if(calibrationPathToT.find("tot") != std::string::npos) {
+              throw DataInvalid("Timepix3: Parameter calibration_path_tot contains substring \"toa\", please update your configuration file!");
+          }
+
           EUDAQ_INFO("Applying ToT calibration from " + calibrationPathToT);
           EUDAQ_INFO("Applying ToA calibration from " + calibrationPathToA);
 


### PR DESCRIPTION
Throw exception if `calibration_path_toa` contains `tot` and vice versa - makes no sense!