### PR TITLE
TPX3 debug output

### DIFF
--- a/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
+++ b/user/timepix3/module/src/Timepix3Event2StdEventConverter.cc
@@ -241,7 +241,7 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
       // Apply calibration if both vtot and vtoa are not empty
       // (copied over from Corryvreckan EventLoaderTimepix3)
       if(!vtot.empty() && !vtoa.empty()) {
-        // EUDAQ_DEBUG()"Applying calibration to DUT"); // cannot change verbosity in Corryvreckan
+        EUDAQ_DEBUG("Applying calibration to DUT");
         size_t scol = static_cast<size_t>(col);
         size_t srow = static_cast<size_t>(row);
         float a = vtot.at(256 * srow + scol).at(2);
@@ -267,8 +267,8 @@ bool Timepix3RawEvent2StdEventConverter::Converting(eudaq::EventSPC ev, eudaq::S
 
         uint64_t t_shift = (toa_c / (fvolts - toa_t) + toa_d) * 1000; // convert to ps
         timestamp -= t_shift; // apply correction
-        // EUDAQ_DEBUG("Time shift = " + to_string(t_shift) + "ps"); // cannot change verbosity in Corryvreckan
-        // EUDAQ_DEBUG("Timestamp calibrated = " + to_string(ftimestamp) + "ps"); // cannot change verbosity in Corryvreckan
+        EUDAQ_DEBUG("Time shift = " + to_string(t_shift) + "ps");
+        EUDAQ_DEBUG("Timestamp calibrated = " + to_string(timestamp) + "ps");
 
         if(col >= 256 || row >= 256) {
             EUDAQ_WARN("Pixel address " + std::to_string(col) + ", " + std::to_string(row) + " is outside of pixel matrix.");


### PR DESCRIPTION
Now that we can change the verbosity of eudaq2 converters from corryvreckan, here's some debug output.

Linked to https://gitlab.cern.ch/corryvreckan/corryvreckan/-/merge_requests/358