### PR TITLE
Add trigger mask parameter to precise trigger calculation

### DIFF
--- a/user/tlu/README.md
+++ b/user/tlu/README.md
@@ -44,6 +44,7 @@ The usage with EUDAQ2 and EUDET-type telescopes is described [here](https://tele
 The conversion of raw data containing **TluRawDataEvent** is the same for both types of TLU. For example and if LCIO is built, you can convert by: ```euCliConverter -i data.raw -o data.slcio```
 The following parameters can be passed in the configuration in order to influence the decoding behavior of this module:
 
+* `trigger_mask`: Trigger mask to allow for an exclusion of particular trigger inputs for the calculation of the precise TLU trigger timestamp. Specified in hexadecimal format, with the i-th trigger corresponding to the i-th bit. Defaults to `0x3F` (all triggers enabled).
 * `delay_scint0`, `delay_scint1`, ..., `delay_scint5`: Delay (time-of-flight + cable delays) of the i-th scintillator in 781.25ps bins as integer. This value is subtracted from the fine timestamp of the i-th scintillator in order to calculate the correct precise TLU trigger timestamp. Defaults to `0`. Please note that the most upstream scintillator should have a delay of zero.
 
 The following flags are forwarded directly from the raw event to the standard event:

--- a/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
+++ b/user/tlu/module/src/TluRawEvent2StdEventConverter.cc
@@ -37,15 +37,17 @@ bool TluRawEvent2StdEventConverter::Converting(eudaq::EventSPC d1, eudaq::Standa
   uint32_t finets4;
   uint32_t finets5;
 
-  // Should I read these in at m_first_time and store in static member variable or read in each time?
+  uint8_t triggerMask = conf->Get("trigger_mask", 0x3F);
   uint32_t delay_scint0 = conf->Get("delay_scint0", 0); // in 781.25ps bins
   uint32_t delay_scint1 = conf->Get("delay_scint1", 0); // in 781.25ps bins
   uint32_t delay_scint2 = conf->Get("delay_scint2", 0); // in 781.25ps bins
   uint32_t delay_scint3 = conf->Get("delay_scint3", 0); // in 781.25ps bins
   uint32_t delay_scint4 = conf->Get("delay_scint4", 0); // in 781.25ps bins
   uint32_t delay_scint5 = conf->Get("delay_scint5", 0); // in 781.25ps bins
+
+  // try/catch for std::stoi()
   try {
-    triggersFired = 0x3F & std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary
+    triggersFired = triggerMask & std::stoi(d1->GetTag("TRIGGER" , "0"), nullptr, 2); // interpret as binary and combine with triggerMask
   } catch (...) {
     EUDAQ_WARN("EUDAQ2 RawEvent flag TRIGGER cannot be interpreted as integer. Cannot calculate precise TLU TS. Return false.");
     return false;


### PR DESCRIPTION
As discussed offline with @simonspa, in some situations it would make sense to add a trigger mask to the offline reconstruction when combining the fine timestamps of the TLU into the precise trigger timestamp.

E.g. when one scintillator performs significantly worse and I want to exclude it from the calculation.
Or when one trigger fires accidentally (e.g. when its input is floating instably).

This MR add a new parameter `trigger_mask` to be set by the user in hex format + adds the description to the README.