### PR TITLE
AD: Fixed `ts_i` reset condition.

### DIFF
--- a/user/caribou/module/src/AD9249EventConverter.cc
+++ b/user/caribou/module/src/AD9249EventConverter.cc
@@ -43,7 +43,7 @@ void AD9249Event2StdEventConverter::decodeChannel(
     if (ch == adc * 8 + 7) {
       // Check if this is a timestamp start - if not, reset timestamp index to
       // zero:
-      if (ts_i < 7 && ts & 0x1 == 0) {
+      if (ts_i < 8 && (ts & 0x1) == 0) {
         ts_i = 0;
       }
     } else {


### PR DESCRIPTION
![sync_is_fine](https://user-images.githubusercontent.com/45600664/166228792-2a98f8ad-e45f-4db9-bb8f-741a1877dfe2.png)
